### PR TITLE
Move compile function to compiler file

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -93,3 +93,17 @@ export default class Compiler {
     }
   }
 }
+
+export async function compile(configPath) {
+  try {
+    let config = {};
+    if (configPath) {
+      const contents = fs.readFileSync(configPath);
+      config = JSON.parse(contents);
+    }
+    const compiler = new Compiler(config);
+    await compiler.compile();
+  } catch (err) {
+    console.error(err);
+  }
+}

--- a/lib/waffle.js
+++ b/lib/waffle.js
@@ -1,6 +1,4 @@
-import fs from 'fs';
 import Ganache from 'ganache-core';
-import Compiler from './compiler';
 import {ContractFactory, providers, Contract, Wallet} from 'ethers';
 import matchers from './matchers';
 import defaultAccounts from './config/defaultAccounts';
@@ -29,20 +27,6 @@ export async function deployContract(wallet, contractJSON, args = [], overrideOp
   const tx = await wallet.sendTransaction(deployTransaction);
   const receipt = await wallet.provider.getTransactionReceipt(tx.hash);
   return new Contract(receipt.contractAddress, abi, wallet);
-}
-
-export async function compile(configPath) {
-  try {
-    let config = {};
-    if (configPath) {
-      const contents = fs.readFileSync(configPath);
-      config = JSON.parse(contents);
-    }
-    const compiler = new Compiler(config);
-    await compiler.compile();
-  } catch (err) {
-    console.error(err);
-  }
 }
 
 export const contractWithWallet = (contract, wallet) =>

--- a/test/compiler/compile.js
+++ b/test/compiler/compile.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import fsx from 'fs-extra';
 import {expect} from 'chai';
-import {compile} from '../../lib/waffle';
+import {compile} from '../../lib/compiler';
 
 describe('Compile', () => {
   it('with custom config', async () => {


### PR DESCRIPTION
Move compile function to compiler file, so that it is no imported by default. That generates problems when testing react UI.