### PR TITLE
Build is now run automatically before publishing to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "waffle": "./bin/waffle"
   },
   "scripts": {
+    "prepublishOnly": "yarn build",
     "test:buildonly": "babel-node script/buildTestContracts",
     "test:nobuild": "export NODE_ENV=test  && mocha --require babel-register --timeout 10000 --recursive --no-warnings",
     "test": "yarn test:buildonly && yarn test:nobuild",


### PR DESCRIPTION
Running a build before publishing ensures you are not deploying an older version of your code by mistake.