### PR TITLE
Set defaults for process and console in compiler

### DIFF
--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -18,8 +18,8 @@ export default class Compiler {
 
   constructor(config: Partial<Config> = {}, options: CompilerOptions = {}) {
     this.config = {...defaultConfig, ...config};
-    this.process = options.overrideProcess;
-    this.console = options.overrideConsole;
+    this.process = options.overrideProcess || process;
+    this.console = options.overrideConsole || console;
     this.wrapper = options.wrapper || createWrapper(this.config);
   }
 


### PR DESCRIPTION
This was causing a build error on beta 9.

```
$ waffle waffle.json
TypeError: Cannot read property 'error' of undefined
    at Compiler.<anonymous> (/Users/liam/src/code/monorepo/node_modules/ethereum-w
affle/dist/compiler.js:141:42)
    at step (/Users/liam/src/code/monorepo/node_modules/ethereum-waffle/dist/compi
ler.js:43:23)
    at Object.next (/Users/liam/src/code/monorepo/node_modules/ethereum-waffle/dis
t/compiler.js:24:53)
    at fulfilled (/Users/liam/src/code/monorepo/node_modules/ethereum-waffle/dist/
compiler.js:15:58)
    at process._tickCallback (internal/process/next_tick.js:68:7)
    at Function.Module.runMain (internal/modules/cjs/loader.js:746:11)
    at startup (internal/bootstrap/node.js:240:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:564:3)
```