### PR TITLE
Replace \ path separators with / in global source file paths for Windows compatibility

### DIFF
--- a/lib/wrappers/baseWrapper.ts
+++ b/lib/wrappers/baseWrapper.ts
@@ -45,7 +45,7 @@ export default class BaseWrapper {
   protected buildSources(inputs: string[]) {
     const sources: Record<string, { urls: string[] }> = {};
     for (const input of inputs) {
-      sources[input] = {urls: [this.getAbsolutePath(input)]};
+      sources[input.replace(/\\/g, '/')] = {urls: [this.getAbsolutePath(input)]};
     }
     return sources;
   }

--- a/lib/wrappers/solcjsWrapper.ts
+++ b/lib/wrappers/solcjsWrapper.ts
@@ -15,8 +15,9 @@ class SolcjsWrapper extends BaseWrapper {
   }
 
   protected convertSources(sources: Record<string, any>) {
-    Object.keys(sources).map((key) => sources[key] = {content: sources[key]});
-    return sources;
+    let convertedSources: Record<string, { content: string }> = {};
+    Object.keys(sources).map((key) => convertedSources[key.replace(/\\/g, '/')] = {content: sources[key]});
+    return convertedSources;
   }
 
   protected async loadCompiler() {


### PR DESCRIPTION
Solc does not support Windows path separators in the global source file paths, leading to solc not being able to find imports when compiling on Windows.