### PR TITLE
Fix a typo in README dependency name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ yarn add ethereum-waffle
 To add external library add npm to your project:
 
 ```sh
-npm i open-zeppelin
+npm i openzeppelin-solidity
 ```
 
 ### Example contract


### PR DESCRIPTION
`open-zeppelin` was renamed to `openzeppelin-solidity`. It was changed in smart contract code but not in README instructions