### PR TITLE
Use rimraf in clean script instead of rm -rf

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "yarn test:buildonly && yarn test:nobuild",
     "lint": "tslint \"lib/**/*.ts\" \"test/**/*.ts\"",
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -fr ./dist ./test/compiler/build ./test/example/build ./test/matchers/build"
+    "clean": "rimraf ./dist ./test/compiler/build ./test/example/build ./test/matchers/build"
   },
   "engines": {
     "node": ">=10.0"
@@ -42,6 +42,7 @@
     "fs-extra": "^7.0.0",
     "mocha": "^5.1.1",
     "openzeppelin-solidity": "^2.1.1",
+    "rimraf": "^2.6.3",
     "sinon": "^6.1.5",
     "sinon-chai": "^3.2.0",
     "solium": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,7 +2540,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.1, glob@~7.1.2:
+glob@^7.0.5, glob@^7.1.1, glob@^7.1.3, glob@~7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
@@ -4408,6 +4408,13 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.6.1:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
+
+rimraf@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@~2.2.6:
   version "2.2.8"


### PR DESCRIPTION
The command `rm -rf` only works on unix-likes, thus the clean script fails on Windows. This replaces the command with the `rimraf` command from the package of the same name. It is a CLI tool that works identically to the `rm -rf` command, removing a file or an entire directory, but is implemented in platform-independent JS.