### PR TITLE
Add compilerOptions to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ yarn-error.log
 /test/projects/custom/custom_build
 /test/projects/insideOut/build
 /test/projects/custom_solidity_4/custom_build
+/test/projects/compilerOptions/build
 /test/matchers/build/
 /test/example/build/
 /build

--- a/lib/compiler/buildUitls.ts
+++ b/lib/compiler/buildUitls.ts
@@ -6,14 +6,14 @@ export function buildSourcesObject(files: ImportFile[]): Record<string, { conten
   return result;
 }
 
-export function buildInputObject(files: ImportFile[], remappings?: any) {
+export function buildInputObject(files: ImportFile[], overrides: any = {}) {
   const sources = buildSourcesObject(files);
   return {
     language: 'Solidity',
     sources,
     settings: {
-      remappings,
-      outputSelection: {'*': {'*': ['abi', 'evm.bytecode', 'evm.deployedBytecode']}}
+      outputSelection: {'*': {'*': ['abi', 'evm.bytecode', 'evm.deployedBytecode']}},
+      ...overrides
     }
   };
 }

--- a/lib/compiler/compileDocker.ts
+++ b/lib/compiler/compileDocker.ts
@@ -1,7 +1,7 @@
 import {join} from 'path';
 import {Config} from '../config/config';
 import {execSync} from 'child_process';
-import {buildInputObject, buildSourcesObject} from './buildUitls';
+import {buildInputObject} from './buildUitls';
 import { ImportFile } from '@resolver-engine/imports';
 
 const CONTAINER_PATH = '/home/project';
@@ -10,7 +10,7 @@ const NPM_PATH = '/home/npm';
 export function compileDocker(config: Config) {
   return async function compile(sources: ImportFile[]) {
     const command = createBuildCommand(config);
-    const input = JSON.stringify(buildInputObject(sources), null, 2);
+    const input = JSON.stringify(buildInputObject(sources, config.compilerOptions), null, 2);
     return JSON.parse(execSync(command, {input}).toString());
   };
 }

--- a/lib/compiler/compileNative.ts
+++ b/lib/compiler/compileNative.ts
@@ -1,13 +1,13 @@
-import {join, resolve} from 'path';
+import {resolve} from 'path';
 import {execSync} from 'child_process';
 import {Config} from '../config/config';
-import {buildInputObject, buildSourcesObject} from './buildUitls';
+import {buildInputObject} from './buildUitls';
 import { ImportFile } from '@resolver-engine/imports';
 
 export function compileNative(config: Config) {
   return async function compile(sources: ImportFile[]) {
     const command = createBuildCommand(config);
-    const input = JSON.stringify(buildInputObject(sources), null, 2);
+    const input = JSON.stringify(buildInputObject(sources, config.compilerOptions), null, 2);
     return JSON.parse(execSync(command, {input}).toString());
   };
 }

--- a/lib/compiler/compileSolcjs.ts
+++ b/lib/compiler/compileSolcjs.ts
@@ -2,7 +2,7 @@ import solc from 'solc';
 import {promisify} from 'util';
 import {readFileContent} from '../utils';
 import {Config} from '../config/config';
-import {buildInputObject, buildSourcesObject} from './buildUitls';
+import {buildInputObject} from './buildUitls';
 import { ImportFile } from '@resolver-engine/imports';
 
 const loadRemoteVersion = promisify(solc.loadRemoteVersion);
@@ -18,7 +18,7 @@ async function loadCompiler(config: Config) {
 export function compileSolcjs(config: Config) {
   return async function compile(sources: ImportFile[], findImports: (file: string) => any) {
     const solc = await loadCompiler(config);
-    const input = buildInputObject(sources);
+    const input = buildInputObject(sources, config.compilerOptions);
     const output = solc.compile(JSON.stringify(input), findImports);
     return JSON.parse(output);
   };

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -7,6 +7,7 @@ export interface Config {
   solcVersion?: string;
   legacyOutput?: string;
   allowedPaths?: string[];
+  compilerOptions?: Record<string, any>;
 }
 
 const defaultConfig: Config = {

--- a/test/compiler/compilerOptions.ts
+++ b/test/compiler/compilerOptions.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import fsx from 'fs-extra';
+import {join} from 'path';
+import {expect} from 'chai';
+import {compileProject} from '../../lib/compiler/compiler';
+import {readFileContent} from '../../lib/utils';
+
+const configs = [
+  'config.json',
+  'config_docker.json',
+  'config_native.json',
+];
+
+describe('E2E: Compiler options', () => {
+  before(() => {
+    process.chdir('test/projects/compilerOptions');
+  });
+
+  beforeEach(() => {
+    fsx.removeSync('build');
+  })
+
+  for (const config of configs) {
+    it(`[${config}] compiles using the provided options`, async () => {
+      await compileProject(config);
+  
+      const filePath = join('./build', 'Constantinople.json');
+      const content = JSON.parse(readFileContent(filePath));
+      expect(content.evm.bytecode.opcodes.includes(' SHL ')).to.equal(true);
+    });
+  }
+
+  after(async () => {
+    process.chdir('../../..');
+  });
+});

--- a/test/compiler/compilerOptions.ts
+++ b/test/compiler/compilerOptions.ts
@@ -8,7 +8,7 @@ import {readFileContent} from '../../lib/utils';
 const configs = [
   'config.json',
   'config_docker.json',
-  'config_native.json',
+  'config_native.json'
 ];
 
 describe('E2E: Compiler options', () => {
@@ -18,12 +18,12 @@ describe('E2E: Compiler options', () => {
 
   beforeEach(() => {
     fsx.removeSync('build');
-  })
+  });
 
   for (const config of configs) {
     it(`[${config}] compiles using the provided options`, async () => {
       await compileProject(config);
-  
+
       const filePath = join('./build', 'Constantinople.json');
       const content = JSON.parse(readFileContent(filePath));
       expect(content.evm.bytecode.opcodes.includes(' SHL ')).to.equal(true);

--- a/test/projects/compilerOptions/config.json
+++ b/test/projects/compilerOptions/config.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "evmVersion": "constantinople"
+  }
+}

--- a/test/projects/compilerOptions/config_docker.json
+++ b/test/projects/compilerOptions/config_docker.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "evmVersion": "constantinople"
+  },
+  "compiler": "dockerized-solc"
+}

--- a/test/projects/compilerOptions/config_native.json
+++ b/test/projects/compilerOptions/config_native.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "evmVersion": "constantinople"
+  },
+  "compiler": "native"
+}

--- a/test/projects/compilerOptions/contracts/Constantinople.sol
+++ b/test/projects/compilerOptions/contracts/Constantinople.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.5.1;
+
+
+contract Constantinople {
+  function constantinople() public pure returns (uint8) {
+    uint8 a = 0;
+    /* solium-disable-next-line */
+    assembly {
+      a := shl(1, 2) // SHL is only available in constantinople
+    }
+    return a;
+  }
+}


### PR DESCRIPTION
This allows passing low level options to the solidity compiler.

Fixes #82