### PR TITLE
fix #90, minor dependency version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@resolver-engine/imports-fs": "^0.3.2",
     "@resolver-engine/imports": "^0.3.2",
-    "ethers": "^4.0.0",
+    "ethers": "^4.0.27",
     "ganache-core": "2.4.0",
     "solc": "^0.5.1"
   },


### PR DESCRIPTION
temp quick fix, would recommend using [greenkeeper](https://greenkeeper.io/) to keep all dep versions up to date (if desired)