### PR TITLE
 Added support to Ganache revert reason in transaction responses

### DIFF
--- a/lib/matchers/matchers.ts
+++ b/lib/matchers/matchers.ts
@@ -26,7 +26,7 @@ const solidity = (chai: any, utils: any) => {
         return value;
       },
       (reason: any) => {
-        reason = ('message' in reason) ? reason.message : reason;
+        reason = (reason instanceof Object && 'message' in reason) ? reason.message : reason;
         const isReverted = reason.toString().search('revert') >= 0;
         const isThrown = reason.toString().search('invalid opcode') >= 0;
         this.assert(isReverted || isThrown,
@@ -55,7 +55,7 @@ const solidity = (chai: any, utils: any) => {
         return value;
       },
       (reason: any) => {
-        reason = ('message' in reason) ? reason.message : reason;
+        reason = (reason instanceof Object && 'message' in reason) ? reason.message : reason;
         const isReverted = reason.toString().search('revert') >= 0 && reason.toString().search(revertReason) >= 0;
         const isThrown = reason.toString().search('invalid opcode') >= 0 && revertReason === '';
         this.assert(isReverted || isThrown,

--- a/lib/matchers/matchers.ts
+++ b/lib/matchers/matchers.ts
@@ -26,6 +26,7 @@ const solidity = (chai: any, utils: any) => {
         return value;
       },
       (reason: any) => {
+        reason = ('message' in reason) ? reason.message : reason;
         const isReverted = reason.toString().search('revert') >= 0;
         const isThrown = reason.toString().search('invalid opcode') >= 0;
         this.assert(isReverted || isThrown,
@@ -54,6 +55,7 @@ const solidity = (chai: any, utils: any) => {
         return value;
       },
       (reason: any) => {
+        reason = ('message' in reason) ? reason.message : reason;
         const isReverted = reason.toString().search('revert') >= 0 && reason.toString().search(revertReason) >= 0;
         const isThrown = reason.toString().search('invalid opcode') >= 0 && revertReason === '';
         this.assert(isReverted || isThrown,


### PR DESCRIPTION
Resolving the condition described in issue #95.

With an external Ganache client, use the `message` attribute of the transaction response, `reason` is an object that `toString()` does not serialize properly.