### PR TITLE
added options for new version of generating output (friendly to KLAB)

### DIFF
--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -8,12 +8,14 @@ export interface Config {
   legacyOutput?: string;
   allowedPaths?: string[];
   compilerOptions?: Record<string, any>;
+  outputType: 'singletons' | 'one-combined' | 'singletons-and-one-combined';
 }
 
 const defaultConfig: Config = {
   sourcesPath: './contracts',
   targetPath: './build',
-  npmPath: 'node_modules'
+  npmPath: 'node_modules',
+  outputType: 'singletons'
 };
 
 export default defaultConfig;


### PR DESCRIPTION
added three versions of generated output:
    * singleton json file for each sol file;
    * one combined json for all (KLAB friendly);
    * both of above.
