### PR TITLE
adding new possible version of generated output of compilation (KLAB friendly)

### DIFF
--- a/docs/release-notes/2.0.10.md
+++ b/docs/release-notes/2.0.10.md
@@ -1,0 +1,27 @@
+# Summary 2.0.10
+
+Add support for generating KLAB (a formal verification tool for Solidity, see: https://github.com/dapphub/klab)
+friendly compilation output.
+
+An example of full KLAB friendly config file is the following:
+
+```
+  module.exports = {
+  compiler: process.env.WAFFLE_COMPILER,
+  legacyOutput: true,
+  outputType: 'all',
+  compilerOptions: {
+    outputSelection: {
+      "*": {
+        "*": [ "evm.bytecode.object", "evm.deployedBytecode.object",
+               "abi" ,
+               "evm.bytecode.sourceMap", "evm.deployedBytecode.sourceMap" ],
+        
+        "": [ "ast" ]
+      },     
+    }
+  }
+};
+```
+
+For details, see updated appropriate documentation file.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -83,6 +83,60 @@ For detailed list of options go to
 `'Target options' <https://solidity.readthedocs.io/en/v0.5.1/using-the-compiler.html#target-options>`_ and `'Compiler Input and Output JSON Description' <https://solidity.readthedocs.io/en/v0.5.1/using-the-compiler.html#compiler-input-and-output-json-description>`_).
 
 
+KLAB compatibility
+------------------
+
+The default compilation process is not compatible with KLAB
+(a formal verification tool, see: https://github.com/dapphub/klab). To compile contracts to work with KLAB one must:
+
+1) Set appropriate compiler options, i.e.:
+
+::
+  compilerOptions: {
+    outputSelection: {
+      "*": {
+        "*": [ "evm.bytecode.object", "evm.deployedBytecode.object",
+               "abi" ,
+               "evm.bytecode.sourceMap", "evm.deployedBytecode.sourceMap" ],
+        
+        "": [ "ast" ]
+      },     
+    }
+  }
+
+2) Set appropriate output type. We support two types: one (default) generates single file for each contract
+and second (KLAB friendly) generates one file (Combined-Json.json) combining all contracts. The second type does not meet 
+(in contrary to the first one) all official solidity standards since KLAB requirements are slightly modified.
+To choice of the output is set in config file, i.e.:
+
+::
+  outputType: 'combined'
+
+Possible options are:
+- `'multiple'`: single file for each contract;
+- `'combined'`: one KLAB friendly file;
+-  `'all'`: generates both above outputs.
+
+An example of full KLAB friendly config file:
+
+::
+  module.exports = {
+  compiler: process.env.WAFFLE_COMPILER,
+  legacyOutput: true,
+  outputType: 'all',
+  compilerOptions: {
+    outputSelection: {
+      "*": {
+        "*": [ "evm.bytecode.object", "evm.deployedBytecode.object",
+               "abi" ,
+               "evm.bytecode.sourceMap", "evm.deployedBytecode.sourceMap" ],
+        
+        "": [ "ast" ]
+      },     
+    }
+  }
+};
+
 Monorepo
 --------
 Waffle works well with mono-repositories. It is enough to set up common npmPath in the configuration file to make it work.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -92,6 +92,7 @@ The default compilation process is not compatible with KLAB
 1) Set appropriate compiler options, i.e.:
 
 ::
+
   compilerOptions: {
     outputSelection: {
       "*": {
@@ -110,6 +111,7 @@ and second (KLAB friendly) generates one file (Combined-Json.json) combining all
 To choice of the output is set in config file, i.e.:
 
 ::
+
   outputType: 'combined'
 
 Possible options are:
@@ -120,6 +122,7 @@ Possible options are:
 An example of full KLAB friendly config file:
 
 ::
+
   module.exports = {
   compiler: process.env.WAFFLE_COMPILER,
   legacyOutput: true,

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -105,6 +105,7 @@ The default compilation process is not compatible with KLAB
     }
   }
 
+
 2) Set appropriate output type. We support two types: one (default) generates single file for each contract
 and second (KLAB friendly) generates one file (Combined-Json.json) combining all contracts. The second type does not meet 
 (in contrary to the first one) all official solidity standards since KLAB requirements are slightly modified.
@@ -124,21 +125,21 @@ An example of full KLAB friendly config file:
 ::
 
   module.exports = {
-  compiler: process.env.WAFFLE_COMPILER,
-  legacyOutput: true,
-  outputType: 'all',
-  compilerOptions: {
-    outputSelection: {
-      "*": {
-        "*": [ "evm.bytecode.object", "evm.deployedBytecode.object",
-               "abi" ,
-               "evm.bytecode.sourceMap", "evm.deployedBytecode.sourceMap" ],
-        
-        "": [ "ast" ]
-      },     
-    }
-  }
-};
+    compiler: process.env.WAFFLE_COMPILER,
+    legacyOutput: true,
+    outputType: 'all',
+    compilerOptions: {
+      outputSelection: {
+        "*": {
+          "*": [ "evm.bytecode.object", "evm.deployedBytecode.object",
+                 "abi" ,
+                 "evm.bytecode.sourceMap", "evm.deployedBytecode.sourceMap" ],
+
+          "": [ "ast" ]
+        },     
+     }
+   }
+  };
 
 Monorepo
 --------

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -89,7 +89,7 @@ KLAB compatibility
 The default compilation process is not compatible with KLAB
 (a formal verification tool, see: https://github.com/dapphub/klab). To compile contracts to work with KLAB one must:
 
-1) Set appropriate compiler options, i.e.:
+1. Set appropriate compiler options, i.e.:
 
 ::
 
@@ -106,7 +106,7 @@ The default compilation process is not compatible with KLAB
   }
 
 
-2) Set appropriate output type. We support two types: one (default) generates single file for each contract
+2. Set appropriate output type. We support two types: one (default) generates single file for each contract
 and second (KLAB friendly) generates one file (Combined-Json.json) combining all contracts. The second type does not meet 
 (in contrary to the first one) all official solidity standards since KLAB requirements are slightly modified.
 To choice of the output is set in config file, i.e.:

--- a/lib/compiler/saveOutput.ts
+++ b/lib/compiler/saveOutput.ts
@@ -28,11 +28,11 @@ export interface ContractJson {
 export async function saveOutput(output: any, config: Config, filesystem = fs) {
   config.outputType = config.outputType || 'multiple';
 
-  if (config.outputType === 'multiple' || config.outputType === 'all') {
+  if (['multiple', 'all'].includes(config.outputType)) {
     saveOutputSingletons(output, config, filesystem);
   }
 
-  if (config.outputType === 'combined' || config.outputType === 'all') {
+  if (['combined', 'all'].includes(config.outputType)) {
     saveOutputCombined(output, config, filesystem);
   }
 }

--- a/lib/compiler/saveOutput.ts
+++ b/lib/compiler/saveOutput.ts
@@ -11,9 +11,14 @@ export interface BytecodeJson {
 
 export interface EvmJson {
   bytecode: BytecodeJson;
+  deployedBytecode: BytecodeJson;
 }
 
 export interface ContractJson {
+  'srcmap-runtime': string;
+  srcmap: string;
+  bin: string;
+  'bin-runtime': string;
   interface: object[];
   abi: object[];
   bytecode: string;
@@ -21,6 +26,18 @@ export interface ContractJson {
 }
 
 export async function saveOutput(output: any, config: Config, filesystem = fs) {
+  config.outputType = config.outputType || 'singletons';
+  
+  if (config.outputType == 'singletons' || config.outputType == 'singletons-and-one-combined') {
+    saveOutputSingletons(output, config, filesystem);
+  }
+    
+  if (config.outputType == 'one-combined' || config.outputType == 'singletons-and-one-combined') {
+    saveOutputCombined(output, config, filesystem);
+  }
+}
+
+export async function saveOutputSingletons(output: any, config: Config, filesystem = fs) {
   for (const [, file] of Object.entries(output.contracts)) {
     for (const [contractName, contractJson] of Object.entries(file)) {
       const filePath = join(config.targetPath, `${contractName}.json`);
@@ -31,6 +48,34 @@ export async function saveOutput(output: any, config: Config, filesystem = fs) {
       filesystem.writeFileSync(filePath, getContent(contractJson, config));
     }
   }
+}
+
+export async function saveOutputCombined(output: any, config: Config, filesystem = fs) {
+  for (const [key, file] of Object.entries(output.contracts)) {
+    for (const [contractName, contractJson] of Object.entries(file)) {
+      contractJson.bin = contractJson.evm.bytecode.object;
+      contractJson['bin-runtime'] = contractJson.evm.deployedBytecode.object;
+      contractJson.srcmap = contractJson.evm.bytecode.sourceMap;
+      contractJson['srcmap-runtime'] = contractJson.evm.deployedBytecode.sourceMap; 
+
+      output.contracts[String(key) + ':' + String(contractName)] = contractJson;
+    };
+    delete output.contracts[key];
+  }
+
+  const allSources: string[] =  [];
+
+  for (const [key, value] of Object.entries(output.sources) as any) {
+      value['AST'] = value['ast'];
+      delete value['ast'];
+      allSources.push(key);
+  }
+
+  output.sourceList = allSources;
+
+  filesystem.writeFileSync(join(config.targetPath, `Combined-Json.json`),
+         JSON.stringify(output, null, 2));
+
 }
 
 function getContent(contractJson: ContractJson, config: Config) {

--- a/lib/compiler/saveOutput.ts
+++ b/lib/compiler/saveOutput.ts
@@ -11,17 +11,17 @@ export interface BytecodeJson {
 
 export interface EvmJson {
   bytecode: BytecodeJson;
-  deployedBytecode: BytecodeJson;
+  deployedBytecode?: BytecodeJson;
 }
 
 export interface ContractJson {
-  'srcmap-runtime': string;
-  srcmap: string;
-  bin: string;
-  'bin-runtime': string;
-  interface: object[];
+  'srcmap-runtime'?: string;
+  srcmap?: string;
+  bin?: string;
+  'bin-runtime'?: string;
+  interface?: object[];
   abi: object[];
-  bytecode: string;
+  bytecode?: string;
   evm: EvmJson;
 }
 

--- a/lib/compiler/saveOutput.ts
+++ b/lib/compiler/saveOutput.ts
@@ -26,13 +26,13 @@ export interface ContractJson {
 }
 
 export async function saveOutput(output: any, config: Config, filesystem = fs) {
-  config.outputType = config.outputType || 'singletons';
+  config.outputType = config.outputType || 'multiple';
 
-  if (config.outputType === 'singletons' || config.outputType === 'singletons-and-one-combined') {
+  if (config.outputType === 'multiple' || config.outputType === 'all') {
     saveOutputSingletons(output, config, filesystem);
   }
 
-  if (config.outputType === 'one-combined' || config.outputType === 'singletons-and-one-combined') {
+  if (config.outputType === 'combined' || config.outputType === 'all') {
     saveOutputCombined(output, config, filesystem);
   }
 }

--- a/lib/compiler/saveOutput.ts
+++ b/lib/compiler/saveOutput.ts
@@ -27,12 +27,12 @@ export interface ContractJson {
 
 export async function saveOutput(output: any, config: Config, filesystem = fs) {
   config.outputType = config.outputType || 'singletons';
-  
-  if (config.outputType == 'singletons' || config.outputType == 'singletons-and-one-combined') {
+
+  if (config.outputType === 'singletons' || config.outputType === 'singletons-and-one-combined') {
     saveOutputSingletons(output, config, filesystem);
   }
-    
-  if (config.outputType == 'one-combined' || config.outputType == 'singletons-and-one-combined') {
+
+  if (config.outputType === 'one-combined' || config.outputType === 'singletons-and-one-combined') {
     saveOutputCombined(output, config, filesystem);
   }
 }
@@ -56,18 +56,18 @@ export async function saveOutputCombined(output: any, config: Config, filesystem
       contractJson.bin = contractJson.evm.bytecode.object;
       contractJson['bin-runtime'] = contractJson.evm.deployedBytecode.object;
       contractJson.srcmap = contractJson.evm.bytecode.sourceMap;
-      contractJson['srcmap-runtime'] = contractJson.evm.deployedBytecode.sourceMap; 
+      contractJson['srcmap-runtime'] = contractJson.evm.deployedBytecode.sourceMap;
 
       output.contracts[String(key) + ':' + String(contractName)] = contractJson;
-    };
+    }
     delete output.contracts[key];
   }
 
   const allSources: string[] =  [];
 
   for (const [key, value] of Object.entries(output.sources) as any) {
-      value['AST'] = value['ast'];
-      delete value['ast'];
+      value.AST = value.ast;
+      delete value.ast;
       allSources.push(key);
   }
 

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -8,6 +8,7 @@ export interface Config {
   legacyOutput?: string;
   allowedPaths?: string[];
   compilerOptions?: Record<string, any>;
+  outputType?: 'singletons' | 'one-combined' | 'singletons-and-one-combined';
 }
 
 const defaultConfig: Config = {

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -8,7 +8,7 @@ export interface Config {
   legacyOutput?: string;
   allowedPaths?: string[];
   compilerOptions?: Record<string, any>;
-  outputType?: 'singletons' | 'one-combined' | 'singletons-and-one-combined';
+  outputType?: 'multiple' | 'combined' | 'all';
 }
 
 const defaultConfig: Config = {

--- a/test/compiler/e2e.ts
+++ b/test/compiler/e2e.ts
@@ -14,7 +14,8 @@ const configurations = [
   './test/projects/custom/config_docker.json',
   './test/projects/custom/config_promise.js',
   './test/projects/custom_solidity_4/config_solcjs.json',
-  './test/projects/custom_solidity_4/config_docker.json'
+  './test/projects/custom_solidity_4/config_docker.json',
+  './test/projects/custom/config_combined.js'
 ];
 
 const artefacts = [

--- a/test/compiler/e2e.ts
+++ b/test/compiler/e2e.ts
@@ -87,6 +87,16 @@ describe('E2E: Compiler integration', async () => {
         });
       }
 
+      if (['all', 'combined'].includes(configuration.outputType)) {
+        it('produce Combined-Json.json', async () => {
+          const filePath = join(targetPath, 'Combined-Json.json');
+          const content = JSON.parse(readFileContent(filePath));
+          expect(content.contracts).to.have.property('contracts');
+          expect(content.contracts).to.have.property('sources');
+          expect(content.contracts).to.have.property('sourceList');
+        });
+      }
+
       it('produce abi', async () => {
         for (const artefact of artefacts) {
           const filePath = join(targetPath, artefact);

--- a/test/compiler/e2e.ts
+++ b/test/compiler/e2e.ts
@@ -91,9 +91,9 @@ describe('E2E: Compiler integration', async () => {
         it('produce Combined-Json.json', async () => {
           const filePath = join(targetPath, 'Combined-Json.json');
           const content = JSON.parse(readFileContent(filePath));
-          expect(content.contracts).to.have.property('contracts');
-          expect(content.contracts).to.have.property('sources');
-          expect(content.contracts).to.have.property('sourceList');
+          expect(content).to.have.property('contracts');
+          expect(content).to.have.property('sources');
+          expect(content).to.have.property('sourceList');
         });
       }
 

--- a/test/projects/custom/config_combined.js
+++ b/test/projects/custom/config_combined.js
@@ -1,0 +1,21 @@
+module.exports = {
+  name: "KLAB friendly configuration",
+  sourcesPath: "./test/projects/custom/custom_contracts",
+  targetPath: "./test/projects/custom/custom_build",
+  npmPath: "./test/projects/custom/custom_node_modules",
+  compiler: process.env.WAFFLE_COMPILER,
+  legacyOutput: true,
+  outputType: 'all',
+  compilerOptions: {
+    outputSelection: {
+      "*": {
+        "*": [ "evm.bytecode.object", "evm.deployedBytecode.object",
+               "abi" ,
+               "evm.bytecode.sourceMap", "evm.deployedBytecode.sourceMap" ],
+        
+        "": [ "ast" ]
+      },     
+    }
+  }
+};
+


### PR DESCRIPTION
added three possible versions of generated output:
    * singleton json file for each sol file (default)
    * one combined json for all (KLAB friendly)
    * both of above