### PR TITLE
Add path to config parameter in createMockProvider

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -12,6 +12,21 @@ To create a mock provider for running your contracts test against it, e.g.:
 
   provider = createMockProvider();
 
+To modify default provider behavior createMockProvider() takes optional Ganache options parameter. It can be object with specified options or absolute path to waffle.json or another config file, e.g.:
+::
+
+  provider = createMockProvider({gasLimit: 0x6691b7, gasPrice: 0x77359400});
+
+  provider = createMockProvider('./waffle.json');
+
+  waffle.json:
+    {
+      ...
+      "ganacheOptions": {
+        "gasLimit": "0x6691b7", 
+        "gasPrice": "0x77359400"
+      }
+    }
 
 Get example wallets
 ^^^^^^^^^^^^^^^^^^^

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -10,6 +10,7 @@ export interface Config {
   compilerOptions?: Record<string, any>;
   outputType?: 'multiple' | 'combined' | 'all';
   outputHumanReadableAbi?: boolean;
+  ganacheOptions?: Record<string, any>;
 }
 
 const defaultConfig: Config = {

--- a/lib/waffle.ts
+++ b/lib/waffle.ts
@@ -8,10 +8,19 @@ import './matchers/matchertypes';
 
 const defaultGanacheOptions = {accounts: defaultAccounts};
 
-export function createMockProvider(ganacheOptions: GanacheOpts = {}) {
+export const createMockProvider = (ganacheOptionsOrPathToConfig: string | GanacheOpts = {}) => {
+  const ganacheOptions = getGanacheOptions(ganacheOptionsOrPathToConfig);
   const options = {...defaultGanacheOptions, ...ganacheOptions };
   return new providers.Web3Provider(Ganache.provider(options));
-}
+};
+
+export const getGanacheOptions = (ganacheOptionsOrPathToConfig: string | GanacheOpts) => {
+  if (typeof ganacheOptionsOrPathToConfig === 'object') {
+    return ganacheOptionsOrPathToConfig;
+  }
+  const {ganacheOptions} = require(ganacheOptionsOrPathToConfig);
+  return ganacheOptions;
+};
 
 export function getWallets(provider: providers.Provider) {
   return defaultAccounts.map((account) => new Wallet(account.secretKey, provider));

--- a/test/projects/getGanacheOptions/config.json
+++ b/test/projects/getGanacheOptions/config.json
@@ -1,0 +1,6 @@
+{
+  "ganacheOptions": {
+    "gasLimit": 50,
+    "gasPrice": 1
+  }
+}

--- a/test/projects/getGanacheOptions/getGanacheOptions.ts
+++ b/test/projects/getGanacheOptions/getGanacheOptions.ts
@@ -1,0 +1,21 @@
+import {expect} from 'chai';
+import {getGanacheOptions} from '../../../lib/waffle';
+import path from 'path';
+
+describe('INTEGRATION: getGanacheOptions', () => {
+  it('ganacheOptions as object', () => {
+    const ganacheOptions = {gasLimit: 50, gasPrice: 1};
+    expect(getGanacheOptions(ganacheOptions)).to.eq(ganacheOptions);
+  });
+
+  it('ganacheOptions as invalid path to config', () => {
+    const pathToConfig = ('./config.json');
+    expect(() => getGanacheOptions(pathToConfig)).to.throw(Error, `Cannot find module './config.json'`);
+  });
+
+  it('ganacheOptions as valid path to config', () => {
+    const pathToConfig = path.join(__dirname, 'config.json');
+    const expectedGanacheOptions = require('./config.json').ganacheOptions;
+    expect(getGanacheOptions(pathToConfig)).to.eq(expectedGanacheOptions);
+  });
+});


### PR DESCRIPTION
Added possibility to provide a path to a config file with Ganache options to createMockProvider.

https://github.com/EthWorks/Waffle/issues/112