### PR TITLE
remove always-true interface key check

### DIFF
--- a/lib/compiler/saveOutput.ts
+++ b/lib/compiler/saveOutput.ts
@@ -82,7 +82,7 @@ export async function saveOutputCombined(output: any, config: Config, filesystem
 }
 
 function getContent(contractJson: ContractJson, config: Config) {
-  if (config.legacyOutput || !contractJson.interface) {
+  if (config.legacyOutput) {
     contractJson.interface = contractJson.abi;
     contractJson.bytecode = contractJson.evm.bytecode.object;
   }


### PR DESCRIPTION
solidity doesn't generate `interface`, so this check always succeeds