### PR TITLE
Fix #149: assertion error message for non-existent events

### DIFF
--- a/lib/matchers/matchers.ts
+++ b/lib/matchers/matchers.ts
@@ -80,7 +80,26 @@ const solidity = (chai: any, utils: any) => {
     const derivedPromise = promise.then((tx: any) =>
       contract.provider.getTransactionReceipt(tx.hash)
     ).then((receipt: any) => {
-      const {topic} = contract.interface.events[eventName];
+      const eventDescription = contract.interface.events[eventName];
+
+      if (eventDescription === undefined) {
+        const isNegated = this.__flags.negate === true;
+
+        this.assert(
+          isNegated,
+          `Expected event "${eventName}" to be emitted, but it doesn't` +
+          ` exist in the contract. Please make sure you've compiled` +
+          ` its latest version before running the test.`,
+          `WARNING: Expected event "${eventName}" NOT to be emitted.` +
+          ` The event wasn't emitted because it doesn't` +
+          ` exist in the contract. Please make sure you've compiled` +
+          ` its latest version before running the test.`,
+          eventName,
+          ''
+        );
+      }
+
+      const {topic} = eventDescription;
       this.logs = filterLogsWithTopics(receipt.logs, topic);
       if (this.logs.length < 1) {
         this.assert(false,

--- a/test/matchers/events.ts
+++ b/test/matchers/events.ts
@@ -32,6 +32,14 @@ describe('INTEGRATION: Events', () => {
     ).to.be.eventually.rejectedWith(AssertionError, 'Expected event "One" to emitted, but wasn\'t');
   });
 
+  it('Emit unexistent event: fail', async () => {
+    await expect(expect(events.emitOne()).to.emit(events, 'Three')).to.be.eventually.rejectedWith(AssertionError, 'Expected event "Three" to be emitted, but it doesn\'t exist in the contract. Please make sure you\'ve compiled its latest version before running the test.');
+  });
+
+  it('Negate emit unexistent event: fail', async () => {
+    await expect(expect(events.emitOne()).not.to.emit(events, 'Three')).to.be.eventually.rejectedWith(AssertionError, 'WARNING: Expected event "Three" NOT to be emitted. The event wasn\'t emitted because it doesn\'t exist in the contract. Please make sure you\'ve compiled its latest version before running the test.');
+  });
+
   it('Emit both: success (two expects)', async () => {
     await expect(events.emitBoth())
       .to.emit(events, 'One')


### PR DESCRIPTION
- [x] Check for non-existent events on `emit` assertion helper to provide proper feedback.