### PR TITLE
Fix #117: emit method name on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sweeter, simpler and faster than Truffle.
 ## Features:
 * Sweet set of chai matchers, e.g.:
   * `expect(...).to.be.revertedWith('Error message')`
-  * `expect(...).to.emitEvent(contract, 'EventName).withArgs(...)`)
+  * `expect(...).to.emit(contract, 'EventName).withArgs(...)`)
 * Importing contracts from npm modules working out of the box, e.g.:
   * `import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";`
 * Fixtures that help write fast and maintainable test suites, e.g.:

--- a/lib/matchers/matchers.ts
+++ b/lib/matchers/matchers.ts
@@ -80,7 +80,26 @@ const solidity = (chai: any, utils: any) => {
     const derivedPromise = promise.then((tx: any) =>
       contract.provider.getTransactionReceipt(tx.hash)
     ).then((receipt: any) => {
-      const {topic} = contract.interface.events[eventName];
+      const eventDescription = contract.interface.events[eventName];
+
+      if (eventDescription === undefined) {
+        const isNegated = this.__flags.negate === true;
+
+        this.assert(
+          isNegated,
+          `Expected event "${eventName}" to be emitted, but it doesn't` +
+          ` exist in the contract. Please make sure you've compiled` +
+          ` its latest version before running the test.`,
+          `WARNING: Expected event "${eventName}" NOT to be emitted.` +
+          ` The event wasn't emitted because it doesn't` +
+          ` exist in the contract. Please make sure you've compiled` +
+          ` its latest version before running the test.`,
+          eventName,
+          ''
+        );
+      }
+
+      const {topic} = eventDescription;
       this.logs = filterLogsWithTopics(receipt.logs, topic);
       if (this.logs.length < 1) {
         this.assert(false,

--- a/test/matchers/events.ts
+++ b/test/matchers/events.ts
@@ -32,6 +32,14 @@ describe('INTEGRATION: Events', () => {
     ).to.be.eventually.rejectedWith(AssertionError, 'Expected event "One" to emitted, but wasn\'t');
   });
 
+  it('Emit unexistent event: fail', async () => {
+    await expect(expect(events.emitOne()).to.emit(events, 'Three')).to.be.eventually.rejectedWith(AssertionError, 'Expected event "Three" to be emitted, but it doesn\'t exist in the contract. Please make sure you\'ve compiled its latest version before running the test.');
+  });
+
+  it('Negate emit unexistent event: fail', async () => {
+    await expect(expect(events.emitOne()).not.to.emit(events, 'Three')).to.be.eventually.rejectedWith(AssertionError, 'WARNING: Expected event "Three" NOT to be emitted. The event wasn\'t emitted because it doesn\'t exist in the contract. Please make sure you\'ve compiled its latest version before running the test.');
+  });
+
   it('Emit both: success (two expects)', async () => {
     await expect(events.emitBoth())
       .to.emit(events, 'One')


### PR DESCRIPTION
Update README to reflect API change for `chai` solidity matchers:
- `emitEvent` -> `emit`