### PR TITLE
Update reference to OpenZeppelin Contracts in docs

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -84,14 +84,14 @@ Import contracts from npm library
 Install library:
 ::
 
-  npm i open-zeppelin
+  npm i @openzeppelin/contracts
 
 
 
 Import solidity files from project imported to npm modules:
 ::
 
-  import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+  import "@openzeppelin/contracts/math/SafeMath.sol";
 
 
 Chai matchers


### PR DESCRIPTION
Documentation referenced installation of OpenZeppelin Contracts erroneously. I have updated the docs to follow the latest version of OpenZeppelin Contracts.

Thanks!