### PR TITLE
quick fix to handle BigNumbers array as argument of the event log

### DIFF
--- a/lib/matchers/matchers.ts
+++ b/lib/matchers/matchers.ts
@@ -122,7 +122,7 @@ const solidity = (chai: any, utils: any) => {
       expectedArgs.length,
       actualArgs.length);
     for (let index = 0; index < expectedArgs.length; index++) {
-      new chai.Assertion(expectedArgs[index]).equal(actualArgs[index]);
+        new chai.Assertion(JSON.stringify(expectedArgs[index])).equal(JSON.stringify(actualArgs[index]));
     }
   };
 

--- a/lib/matchers/matchers.ts
+++ b/lib/matchers/matchers.ts
@@ -121,15 +121,15 @@ const solidity = (chai: any, utils: any) => {
       'Do not combine .not. with .withArgs()',
       expectedArgs.length,
       actualArgs.length);
-      for (let index = 0; index < expectedArgs.length; index++) {
-        if (expectedArgs[index].length !== undefined && typeof expectedArgs[index] !== "string"){
-            for (let j = 0; j < expectedArgs[index].length; j++){
-                new chai.Assertion(expectedArgs[index][j]).equal(actualArgs[index][j]);
-            }
-        } else {
-            new chai.Assertion((expectedArgs[index])).equal((actualArgs[index]));
+    for (let index = 0; index < expectedArgs.length; index++) {
+      if (expectedArgs[index].length !== undefined && typeof expectedArgs[index] !== 'string') {
+        for (let j = 0; j < expectedArgs[index].length; j++) {
+          new chai.Assertion(expectedArgs[index][j]).equal(actualArgs[index][j]);
         }
-     }
+      } else {
+        new chai.Assertion((expectedArgs[index])).equal((actualArgs[index]));
+      }
+    }
   };
 
   Assertion.addMethod('withArgs', function (...expectedArgs: any[]) {

--- a/lib/matchers/matchers.ts
+++ b/lib/matchers/matchers.ts
@@ -121,9 +121,15 @@ const solidity = (chai: any, utils: any) => {
       'Do not combine .not. with .withArgs()',
       expectedArgs.length,
       actualArgs.length);
-    for (let index = 0; index < expectedArgs.length; index++) {
-        new chai.Assertion(JSON.stringify(expectedArgs[index])).equal(JSON.stringify(actualArgs[index]));
-    }
+      for (let index = 0; index < expectedArgs.length; index++) {
+        if (expectedArgs[index].length !== undefined && typeof expectedArgs[index] !== "string"){
+            for (let j = 0; j < expectedArgs[index].length; j++){
+                new chai.Assertion(expectedArgs[index][j]).equal(actualArgs[index][j]);
+            }
+        } else {
+            new chai.Assertion((expectedArgs[index])).equal((actualArgs[index]));
+        }
+     }
   };
 
   Assertion.addMethod('withArgs', function (...expectedArgs: any[]) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:nobuild": "export NODE_ENV=test && mocha",
     "test": "yarn test:buildonly && yarn test:nobuild",
     "lint": "eslint '{lib,test}/**/*.ts'",
+    "lint:fix": "eslint --fix '{lib,test}/**/*.ts'",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rimraf ./dist ./test/compiler/build ./test/example/build ./test/matchers/build"
   },

--- a/test/matchers/contracts/events.sol
+++ b/test/matchers/contracts/events.sol
@@ -5,8 +5,9 @@ contract Events {
 
     event One(uint value, string msg, bytes32 encoded);
     event Two(uint indexed value, string msg);
+    event Arrays(uint256[3] value, bytes32[2] encoded);
 
-    function emitOne() public {
+  function emitOne() public {
         emit One(1, "One", 0x00cFBbaF7DDB3a1476767101c12a0162e241fbAD2a0162e2410cFBbaF7162123);
     }
 
@@ -17,6 +18,16 @@ contract Events {
     function emitBoth() public {
         emit One(1, "One", 0x0000000000000000000000000000000000000000000000000000000000000001);
         emit Two(2, "Two");
+    }
+
+    function emitArrays() public {
+        emit Arrays([
+          uint256(1),
+          uint256(2),
+          uint256(3)],
+          [
+          bytes32(0x00cFBbaF7DDB3a1476767101c12a0162e241fbAD2a0162e2410cFBbaF7162123),
+          bytes32(0x00cFBbaF7DDB3a1476767101c12a0162e241fbAD2a0162e2410cFBbaF7162124)]);
     }
 
     function doNotEmit() pure public {

--- a/test/matchers/events.ts
+++ b/test/matchers/events.ts
@@ -1,7 +1,7 @@
 import {expect, AssertionError} from 'chai';
 import {createMockProvider, deployContract, getWallets} from '../../lib';
 import Events from './build/Events.json';
-import {Contract} from 'ethers';
+import {Contract, utils} from 'ethers';
 
 describe('INTEGRATION: Events', () => {
   const provider = createMockProvider();
@@ -102,6 +102,51 @@ describe('INTEGRATION: Events', () => {
       AssertionError,
       'expected \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162124\' ' +
       'to equal \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162123\''
+    );
+  });
+
+  it('Event with array of BigNumbers and bytes32 types', async () => {
+    await expect(events.emitArrays()).to.emit(events, 'Arrays')
+      .withArgs(
+        [1, 2, 3],
+        ['0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162123',
+          '0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162124']);
+  });
+
+  it('Event with array of BigNumbers providing bignumbers to the matcher', async () => {
+    await expect(events.emitArrays()).to.emit(events, 'Arrays')
+      .withArgs(
+        [utils.bigNumberify(1), 2, utils.bigNumberify(3)],
+        ['0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162123',
+          '0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162124']);
+  });
+
+  it('Event with one different arg within array (bytes32)', async () => {
+    await expect(
+      expect(events.emitArrays()).to.emit(events, 'Arrays')
+        .withArgs(
+          [utils.bigNumberify(1), 2, utils.bigNumberify(3)],
+          ['0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162121',
+            '0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162124'])
+    ).to.be.eventually.rejectedWith(
+      AssertionError,
+      'expected \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162121\' ' +
+      'to equal \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162123\''
+    );
+  });
+
+  it('Event with one different arg within array (BigNumber)', async () => {
+    await expect(
+      expect(events.emitArrays()).to.emit(events, 'Arrays')
+        .withArgs(
+          [0, 2, 3],
+          ['0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162123',
+            '0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162124'])
+    ).to.be.eventually.rejectedWith(
+      AssertionError,
+      // eslint-disable-next-line no-useless-escape
+      'Expected \"0\" ' +
+      'to be equal 1'
     );
   });
 });


### PR DESCRIPTION
expected:
as        ```[ BigNumber { _hex: '0x01f4' }, BigNumber { _hex: '0x01f4' } ]``` 
equals ```[ BigNumber { _hex: '0x01f4' }, BigNumber { _hex: '0x01f4' } ]``` 
- it should passes the test

as        ```[ BigNumber { _hex: '0x01f4' }, BigNumber { _hex: '0x01f4' } ]``` 
equals ```[ 500, 500 ]``` 
- it should passes the test

actual:
```
AssertionError: expected [ Array(2) ] to equal [ Array(2) ]
    at assertArgsArraysEqual (src/test/productAssetIdentity.spec.ts:65:51)
    at derivedPromise.promise.then (src/test/productAssetIdentity.spec.ts:71:9)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
```
AssertionError: expected [ Array(2) ] to equal [ 500, 500 ]
    at assertArgsArraysEqual (src/test/productAssetIdentity.spec.ts:65:51)
    at derivedPromise.promise.then (src/test/productAssetIdentity.spec.ts:71:9)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
switching to deep.equal also doesn't solve the issue...

quick and dirty fix is to stringify the `actualArgs` and `expectedArgs` values of every argument within `withArgs` method.

however this makes `equal` method overwrites to handle BigNumbers useless...

as an alternative if the value is an array we can compare each value separately (last commit)