### PR TITLE
Increase max buffer during native compilation (#179)

### DIFF
--- a/waffle-compiler/src/compileNative.ts
+++ b/waffle-compiler/src/compileNative.ts
@@ -8,7 +8,7 @@ export function compileNative(config: Config) {
   return async function compile(sources: ImportFile[]) {
     const command = createBuildCommand(config);
     const input = JSON.stringify(buildInputObject(sources, config.compilerOptions), null, 2);
-    return JSON.parse(execSync(command, {input}).toString());
+    return JSON.parse(execSync(command, {input, maxBuffer: 1024 * 1024 * 4}).toString());
   };
 }
 


### PR DESCRIPTION
Closes #179 (for real this time)
(This problem was also discussed in [solidity issue 8133](https://github.com/ethereum/solidity/issues/8133))

In `waffle-compiler/src/compileNative.ts` we're calling `execSync` and not specifying a `maxBuffer` option so it defaults to `1024 * 1024`. This is a sane default & works for most cases but my org is trying to compile a [bunch of contracts](https://github.com/ConnextProject/indra/tree/staging/modules/contracts/contracts) and either the input or output exceeds this default.

This PR simply specifies a `maxBuffer` value that's 4x this default (we need a value ~2.5x bigger than the default so 4x gives us a fair bit of wiggle room). Because this option specifies a **max** limit on the buffer size, I don't think increasing this limit would have any effect on other projects which are compiling fewer contracts.