### PR TITLE
Add Vyper compilation

### DIFF
--- a/waffle-compiler/src/buildUitls.ts
+++ b/waffle-compiler/src/buildUitls.ts
@@ -8,10 +8,14 @@ export function buildSourcesObject(files: ImportFile[]): Record<string, { conten
   return result;
 }
 
-export function buildInputObject(files: ImportFile[], overrides: any = {}) {
+export function buildInputObject(
+  files: ImportFile[],
+  overrides: any = {},
+  language: 'Solidity' | 'Vyper' = 'Solidity'
+) {
   const sources = buildSourcesObject(files);
   return {
-    language: 'Solidity',
+    language,
     sources,
     settings: {
       outputSelection: {'*': {'*': ['abi', 'evm.bytecode', 'evm.deployedBytecode']}},

--- a/waffle-compiler/src/compileDockerSolc.ts
+++ b/waffle-compiler/src/compileDockerSolc.ts
@@ -1,0 +1,31 @@
+import {join} from 'path';
+import {Config} from './config';
+import {execSync} from 'child_process';
+import {buildInputObject} from './buildUitls';
+import {ImportFile} from '@resolver-engine/imports';
+import {solcOutputMaxBuffer} from './compiler';
+
+const CONTAINER_PATH = '/home/project';
+const NPM_PATH = '/home/npm';
+
+export function compileDockerSolc(config: Config) {
+  return async function compile(sources: ImportFile[]) {
+    const command = createBuildCommand(config);
+    const input = JSON.stringify(buildInputObject(sources, config.compilerOptions), null, 2);
+    return JSON.parse(execSync(command, {input, maxBuffer: solcOutputMaxBuffer}).toString());
+  };
+}
+
+export function createBuildCommand(config: Config) {
+  const configTag = config.compilerVersion;
+  const tag = configTag ? `:${configTag}` : ':stable';
+  const allowedPaths = `"${CONTAINER_PATH},${NPM_PATH}"`;
+  return `docker run ${getVolumes(config)} -i -a stdin -a stdout ` +
+    `ethereum/solc${tag} solc --standard-json --allow-paths ${allowedPaths}`;
+}
+
+export function getVolumes(config: Config) {
+  const hostPath = process.cwd();
+  const hostNpmPath = join(hostPath, config.nodeModulesDirectory);
+  return `-v ${hostPath}:${CONTAINER_PATH} -v ${hostNpmPath}:${NPM_PATH}`;
+}

--- a/waffle-compiler/src/compileNativeSolc.ts
+++ b/waffle-compiler/src/compileNativeSolc.ts
@@ -5,7 +5,7 @@ import {buildInputObject} from './buildUitls';
 import {ImportFile} from '@resolver-engine/imports';
 import {solcOutputMaxBuffer} from './compiler';
 
-export function compileNative(config: Config) {
+export function compileNativeSolc(config: Config) {
   return async function compile(sources: ImportFile[]) {
     const command = createBuildCommand(config);
     const input = JSON.stringify(buildInputObject(sources, config.compilerOptions), null, 2);

--- a/waffle-compiler/src/config/inputToConfig.ts
+++ b/waffle-compiler/src/config/inputToConfig.ts
@@ -66,7 +66,7 @@ function validate(config: any): asserts config is Config {
 const checkSourceDirectory = checkType('sourceDirectory', 'string');
 const checkOutputDirectory = checkType('outputDirectory', 'string');
 const checkNodeModulesDirectory = checkType('nodeModulesDirectory', 'string');
-const checkCompilerType = checkEnum('compilerType', ['native', 'dockerized-solc', 'solcjs']);
+const checkCompilerType = checkEnum('compilerType', ['native', 'dockerized-solc', 'solcjs', 'dockerized-vyper']);
 const checkCompilerVersion = checkType('compilerVersion', 'string');
 
 function checkCompilerAllowedPaths(compilerAllowedPaths: unknown) {

--- a/waffle-compiler/src/findInputs.ts
+++ b/waffle-compiler/src/findInputs.ts
@@ -12,7 +12,7 @@ export function findInputs(sourcePath: string) {
       const filePath = path.join(dir, file);
       if (isDirectory(filePath)) {
         stack.push(filePath);
-      } else if (file.endsWith('.sol')) {
+      } else if (file.endsWith('.sol') || file.endsWith('.vy')) {
         inputFiles.push(filePath);
       }
     }

--- a/waffle-compiler/src/getCompileFunction.ts
+++ b/waffle-compiler/src/getCompileFunction.ts
@@ -1,7 +1,8 @@
 import {Config} from './config';
 import {compileSolcjs} from './compileSolcjs';
-import {compileNative} from './compileNative';
-import {compileDocker} from './compileDocker';
+import {compileNativeSolc} from './compileNativeSolc';
+import {compileDockerSolc} from './compileDockerSolc';
+import {compileDockerVyper} from './compileDockerVyper';
 import {ImportFile} from '@resolver-engine/imports';
 
 export type CompileFunction = (
@@ -11,11 +12,13 @@ export type CompileFunction = (
 
 export function getCompileFunction(config: Config): CompileFunction {
   if (config.compilerType === 'native') {
-    return compileNative(config);
+    return compileNativeSolc(config);
   } else if (config.compilerType === 'dockerized-solc') {
-    return compileDocker(config);
+    return compileDockerSolc(config);
   } else if (config.compilerType === 'solcjs') {
     return compileSolcjs(config);
+  } else if (config.compilerType === 'dockerized-vyper') {
+    return compileDockerVyper(config);
   }
   throw new Error(`Unknown compiler ${config.compilerType}`);
 }

--- a/waffle-compiler/test/compiler/e2e_vyper.ts
+++ b/waffle-compiler/test/compiler/e2e_vyper.ts
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import fsx from 'fs-extra';
+import {join, dirname, basename} from 'path';
+import {expect} from 'chai';
+import {compileProject} from '../../src/compiler';
+import {loadConfig} from '../../src/loadConfig';
+import {readFileContent, isFile} from '../../src/utils';
+
+const configurations = [
+  './test/projects/vyper0.1/config_vyper_0b15.json',
+  './test/projects/vyper0.1/config_vyper_0b17.json'
+];
+
+const artifacts: string[] = [
+  'Custom.json'
+];
+
+describe('E2E: Vyper Compiler integration', async () => {
+  for (const configurationPath of configurations) {
+    const configuration = await loadConfig(configurationPath) as any;
+    const {name, outputDirectory} = configuration;
+
+    describe(`E2E: ${name}`, () => {
+      const dir = process.cwd();
+
+      before(async () => {
+        process.chdir(dirname(configurationPath));
+        fsx.removeSync(outputDirectory);
+      });
+
+      it('compiles without errors', async () => {
+        await compileProject(basename(configurationPath));
+      });
+
+      after(() => {
+        process.chdir(dir);
+      });
+
+      it('produce output files', async () => {
+        expect(fs.existsSync(outputDirectory), `Expected build path "${outputDirectory}" to exist.`).to.equal(true);
+        for (const artefact of artifacts) {
+          const filePath = join(outputDirectory, artefact);
+          expect(isFile(filePath), `Expected compilation artefact "${filePath}" to exist.`).to.equal(true);
+        }
+      });
+
+      it('produce bytecode', async () => {
+        for (const artefact of artifacts) {
+          const filePath = join(outputDirectory, artefact);
+          const content = JSON.parse(readFileContent(filePath));
+          expect(content.evm, `Compilation artefact "${filePath}" expected to contain evm section`).to.be.ok;
+          expect(content.evm.bytecode.object).to.startWith('0x');
+        }
+      });
+
+      it('produce legacy bytecode', async () => {
+        for (const artefact of artifacts) {
+          const filePath = join(outputDirectory, artefact);
+          const content = JSON.parse(readFileContent(filePath));
+          expect(content.bytecode).to.deep.eq(content.evm.bytecode.object);
+          expect(content.interface).to.deep.eq(content.abi);
+        }
+      });
+
+      it('produce abi', async () => {
+        for (const artefact of artifacts) {
+          const filePath = join(outputDirectory, artefact);
+          const content = JSON.parse(readFileContent(filePath));
+          expect(content.abi, `"${filePath}" expected to have abi`).to.be.an.instanceOf(Array);
+          expect(
+            content.abi,
+            `"${filePath}" abi expected to be array, but was "${typeof content.abi}"`
+          ).to.be.an('array');
+          expect(
+            content.abi[0],
+            `"${filePath}" abi expected to contain objects, but was "${typeof content.abi[0]}"`
+          ).to.be.an('object');
+        }
+      });
+    });
+  }
+});

--- a/waffle-compiler/test/compiler/wrappers/compileDocker.ts
+++ b/waffle-compiler/test/compiler/wrappers/compileDocker.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {getVolumes, createBuildCommand} from '../../../src/compileDocker';
+import {getVolumes, createBuildCommand} from '../../../src/compileDockerSolc';
 import {join} from 'path';
 import {Config} from '../../../src/config';
 

--- a/waffle-compiler/test/compiler/wrappers/compileNative.ts
+++ b/waffle-compiler/test/compiler/wrappers/compileNative.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {createBuildCommand} from '../../../src/compileNative';
+import {createBuildCommand} from '../../../src/compileNativeSolc';
 import {Config} from '../../../src/config';
 
 const sourceDirectory = './test/projects/custom/custom_contracts';

--- a/waffle-compiler/test/projects/vyper0.1/config_vyper_0b15.json
+++ b/waffle-compiler/test/projects/vyper0.1/config_vyper_0b15.json
@@ -1,0 +1,7 @@
+{
+  "name": "Vyper 0.1.0b15 - docker",
+  "sourceDirectory": "./custom_contracts",
+  "outputDirectory": "./custom_build",
+  "compilerType": "dockerized-vyper",
+  "compilerVersion": "0.1.0b15"
+}

--- a/waffle-compiler/test/projects/vyper0.1/config_vyper_0b17.json
+++ b/waffle-compiler/test/projects/vyper0.1/config_vyper_0b17.json
@@ -1,0 +1,7 @@
+{
+  "name": "Vyper 0.1.0b17 - docker",
+  "sourceDirectory": "./custom_contracts",
+  "outputDirectory": "./custom_build",
+  "compilerType": "dockerized-vyper",
+  "compilerVersion": "0.1.0b17"
+}

--- a/waffle-compiler/test/projects/vyper0.1/custom_contracts/Custom.vy
+++ b/waffle-compiler/test/projects/vyper0.1/custom_contracts/Custom.vy
@@ -1,0 +1,6 @@
+name: public(string[64])
+
+
+@public
+def __init__(_name: string[64]):
+    self.name = _name


### PR DESCRIPTION
- Progresses https://github.com/EthWorks/Waffle/issues/206
- I think next steps could be:
    - Add more `.vy` contracts for more solid tests, including library linking
    - Possibly rewrite to vyper all current `.sol` contracts like `One.sol` or `Two.sol` and then merge `e2e.ts` and `e2e_vyper.ts` together?