### PR TITLE
Added ability to lookup mock function by signature.

### DIFF
--- a/waffle-mock-contract/README.md
+++ b/waffle-mock-contract/README.md
@@ -49,6 +49,27 @@ await mockContract.mock.<nameOfMethod>.reverts()
 await mockContract.mock.<nameOfMethod>.withArgs(<arguments>).reverts()
 ```
 
+Sometimes you may have an overloaded function name:
+
+```solidity
+contract OverloadedFunctions is Ownable {
+  function burn(uint256 amount) external returns (bool) {
+    // ...
+  }
+
+  function burn(address user, uint256 amount) external onlyOwner returns (bool) {
+    // ...
+  }
+}
+```
+
+You may choose which function to call by using its signature:
+
+```js
+await mockContract.mock['burn(uint256)'].returns(true)
+await mockContract.mock['burn(address,uint256)'].withArgs('0x1234...', 1000).reverts()
+```
+
 ## Example
 
 The example below illustrates how `mock-contract` can be used to test the very simple `AmIRichAlready` contract.

--- a/waffle-mock-contract/src/index.ts
+++ b/waffle-mock-contract/src/index.ts
@@ -30,11 +30,14 @@ function createMock(abi: ABI, mockContractInstance: Contract) {
   const {functions} = new utils.Interface(abi);
   const encoder = new utils.AbiCoder();
 
-  return Object.values(functions).reduce((acc, func) => ({
-    ...acc,
-    [func.name]: stub(mockContractInstance, encoder, func),
-    [func.format()]: stub(mockContractInstance, encoder, func)
-  }), {} as MockContract['mock']);
+  return Object.values(functions).reduce((acc, func) => {
+    let stubbed = stub(mockContractInstance, encoder, func);
+    return {
+      ...acc,
+      [func.name]: stubbed,
+      [func.format()]: stubbed
+    }
+  }, {} as MockContract['mock']);
 }
 
 export type Stub = ReturnType<typeof stub>;

--- a/waffle-mock-contract/src/index.ts
+++ b/waffle-mock-contract/src/index.ts
@@ -32,7 +32,8 @@ function createMock(abi: ABI, mockContractInstance: Contract) {
 
   return Object.values(functions).reduce((acc, func) => ({
     ...acc,
-    [func.name]: stub(mockContractInstance, encoder, func)
+    [func.name]: stub(mockContractInstance, encoder, func),
+    [func.format()]: stub(mockContractInstance, encoder, func)
   }), {} as MockContract['mock']);
 }
 

--- a/waffle-mock-contract/src/index.ts
+++ b/waffle-mock-contract/src/index.ts
@@ -36,7 +36,7 @@ function createMock(abi: ABI, mockContractInstance: Contract) {
       ...acc,
       [func.name]: stubbed,
       [func.format()]: stubbed
-    }
+    };
   }, {} as MockContract['mock']);
 }
 

--- a/waffle-mock-contract/src/index.ts
+++ b/waffle-mock-contract/src/index.ts
@@ -31,7 +31,7 @@ function createMock(abi: ABI, mockContractInstance: Contract) {
   const encoder = new utils.AbiCoder();
 
   return Object.values(functions).reduce((acc, func) => {
-    let stubbed = stub(mockContractInstance, encoder, func);
+    const stubbed = stub(mockContractInstance, encoder, func);
     return {
       ...acc,
       [func.name]: stubbed,

--- a/waffle-mock-contract/test/contract.test.ts
+++ b/waffle-mock-contract/test/contract.test.ts
@@ -48,6 +48,17 @@ describe('Doppelganger - Contract', () => {
       expect(await pretender.add(5)).to.equal(returnedValue);
     });
 
+    it('allows function to be looked up by signature', async () => {
+      const {contract, pretender} = await deploy();
+      const addSignature = '0x1003e2d2';
+      const callData = `${addSignature}0000000000000000000000000000000000000000000000000000000000000005`;
+      const returnedValue = '0x1000000000000000000000000000000000000000000000000000000000004234';
+
+      await contract.__waffle__mockReturns(callData, returnedValue);
+
+      expect(await pretender['add(uint256)'](5)).to.equal(returnedValue);
+    });
+
     it('reverts if mock was set up for call with some argument and method was called with another', async () => {
       const {contract, pretender} = await deploy();
       const addSignature = '0x1003e2d2';

--- a/waffle-mock-contract/test/contract.test.ts
+++ b/waffle-mock-contract/test/contract.test.ts
@@ -5,6 +5,7 @@ import {Contract, ContractFactory} from 'ethers';
 
 import DoppelgangerContract from '../src/Doppelganger.json';
 import Counter from './helpers/interfaces/Counter.json';
+import CounterOverloaded from './helpers/interfaces/CounterOverloaded.json';
 
 use(chaiAsPromised);
 
@@ -18,8 +19,9 @@ describe('Doppelganger - Contract', () => {
       const factory = new ContractFactory(DoppelgangerContract.abi, DoppelgangerContract.bytecode, wallet);
       const contract = await factory.deploy();
       const pretender = new Contract(contract.address, Counter.abi, wallet);
+      const pretenderOverloaded = new Contract(contract.address, CounterOverloaded.abi, wallet);
 
-      return {contract, pretender};
+      return {contract, pretender, pretenderOverloaded};
     };
 
     it('reverts when trying to call a not initialized method', async () => {
@@ -49,14 +51,14 @@ describe('Doppelganger - Contract', () => {
     });
 
     it('allows function to be looked up by signature', async () => {
-      const {contract, pretender} = await deploy();
-      const addSignature = '0x1003e2d2';
-      const callData = `${addSignature}0000000000000000000000000000000000000000000000000000000000000005`;
+      const {contract, pretenderOverloaded} = await deploy();
+      const addSignature = '0x4f2be91f';
+      const callData = `${addSignature}`;
       const returnedValue = '0x1000000000000000000000000000000000000000000000000000000000004234';
 
       await contract.__waffle__mockReturns(callData, returnedValue);
 
-      expect(await pretender['add(uint256)'](5)).to.equal(returnedValue);
+      expect(await pretenderOverloaded['add()']()).to.equal(returnedValue);
     });
 
     it('reverts if mock was set up for call with some argument and method was called with another', async () => {

--- a/waffle-mock-contract/test/helpers/contracts/CounterOverloaded.sol
+++ b/waffle-mock-contract/test/helpers/contracts/CounterOverloaded.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.6.3;
+
+contract CounterOverloaded {
+    uint private value;
+
+    function increment() public {
+        value += 1;
+    }
+
+    function read() public view returns (uint) {
+        return value;
+    }
+
+    function add() public view returns (uint) {
+        return value + 1;
+    }
+
+    function add(uint a) public view returns (uint) {
+        return value + a;
+    }
+
+    function testArgumentTypes(uint a, bool b, string memory s, bytes memory bs) public pure returns (bytes memory ret) {
+        ret = abi.encodePacked(a, b, s, bs);
+    }
+}


### PR DESCRIPTION
Addresses issue https://github.com/EthWorks/Waffle/issues/289.

Copied here:

The mock functions are keyed only on the function name, so if there are multiple functions with the same name only one is available.

This is ideal in most situations, but it would be great if we could also key on the full function signature (like ethers). For example:

```javascript
await token.mock.mint.withArgs(user1, 10000)
// can be 
await token.mock['mint(address,uint256)'].withArgs(user1, 10000)
```

This would be a very small and beneficial change.