### PR TITLE
Add waffle-chai usage example

### DIFF
--- a/waffle-chai/README.md
+++ b/waffle-chai/README.md
@@ -22,6 +22,16 @@ yarn add --dev @ethereum-waffle/chai
 npm install --save-dev @ethereum-waffle/chai
 ```
 
+## Usage
+```ts
+import { expect, use } from "chai";
+import { waffleChai } from "@ethereum-waffle/chai";
+
+use(chaiAsPromised);
+
+expect(new BigNumber(6)).to.be.gt(0);
+```
+
 ## Feature overview
 
 **NOTE**: You do not need to use this package directly. You can install it through the main package (`ethereum-waffle`) and use it instead.

--- a/waffle-chai/README.md
+++ b/waffle-chai/README.md
@@ -26,10 +26,11 @@ npm install --save-dev @ethereum-waffle/chai
 ```ts
 import { expect, use } from "chai";
 import { waffleChai } from "@ethereum-waffle/chai";
+import { bigNumberify } from "ethers/utils";
 
 use(chaiAsPromised);
 
-expect(new BigNumber(6)).to.be.gt(0);
+expect(bigNumberify("6")).to.be.gt(0);
 ```
 
 ## Feature overview


### PR DESCRIPTION
I needed to use these matchers directly without the rest of the Waffle project. The instructions for doing this could be more descriptive, so I added a little extra info.