### PR TITLE
[docs] Fix the path to the example contract

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -42,7 +42,7 @@ Add an external library by installing it with yarn or npm:
 Writing a contract
 ------------------
 
-Below is an example contract written in Solidity. Place it in :code:`contracts/BasicToken.sol` file of your project:
+Below is an example contract written in Solidity. Place it in :code:`src/BasicToken.sol` file of your project:
 
 .. code-block:: solidity
 


### PR DESCRIPTION
The default config of waffle looks for contracts in `src/`, not in `contracts/`, so I corrected the path.