### PR TITLE
Enable loading of custom config files when `waffle.json` is present

### DIFF
--- a/waffle-compiler/src/config/loadConfig.ts
+++ b/waffle-compiler/src/config/loadConfig.ts
@@ -3,10 +3,10 @@ import path from 'path';
 import {InputConfig} from './config';
 
 export async function loadConfig(configPath?: string): Promise<InputConfig> {
-  if (fs.existsSync('./waffle.json')) {
-    return require(path.join(process.cwd(), './waffle.json'));
-  } else if (configPath) {
+  if (configPath) {
     return require(path.join(process.cwd(), configPath));
+  } else if (fs.existsSync('./waffle.json')) {
+    return require(path.join(process.cwd(), './waffle.json'));
   } else {
     return {};
   }


### PR DESCRIPTION
Right now the below command runs waffle with the default `waffle.json` config file if it is present in the current working directory:
```
waffle custom-config.json
```

This PR fixes this behaviour.