### PR TITLE
Make emit matcher error messages follow chai convention

### DIFF
--- a/waffle-chai/src/matchers/emit.ts
+++ b/waffle-chai/src/matchers/emit.ts
@@ -55,7 +55,7 @@ export function supportEmit(Assertion: Chai.AssertionStatic) {
     context.assert(
       actualArgs.length === expectedArgs.length,
       `Expected "${context.eventName}" event to have ${expectedArgs.length} argument(s), ` +
-      `but has ${actualArgs.length}`,
+      `but it has ${actualArgs.length}`,
       'Do not combine .not. with .withArgs()',
       expectedArgs.length,
       actualArgs.length
@@ -63,10 +63,10 @@ export function supportEmit(Assertion: Chai.AssertionStatic) {
     for (let index = 0; index < expectedArgs.length; index++) {
       if (expectedArgs[index].length !== undefined && typeof expectedArgs[index] !== 'string') {
         for (let j = 0; j < expectedArgs[index].length; j++) {
-          new Assertion(expectedArgs[index][j]).equal(actualArgs[index][j]);
+          new Assertion(actualArgs[index][j]).equal(expectedArgs[index][j]);
         }
       } else {
-        new Assertion((expectedArgs[index])).equal((actualArgs[index]));
+        new Assertion((actualArgs[index])).equal((expectedArgs[index]));
       }
     }
   };

--- a/waffle-chai/test/matchers/events.test.ts
+++ b/waffle-chai/test/matchers/events.test.ts
@@ -110,7 +110,7 @@ describe('INTEGRATION: Events', () => {
       expect(events.emitOne()).to.emit(events, 'One').withArgs(1)
     ).to.be.eventually.rejectedWith(
       AssertionError,
-      'Expected "One" event to have 1 argument(s), but has 3'
+      'Expected "One" event to have 1 argument(s), but it has 3'
     );
   });
 
@@ -119,7 +119,7 @@ describe('INTEGRATION: Events', () => {
       expect(events.emitOne()).to.emit(events, 'One').withArgs(1, 2, 3, 4)
     ).to.be.eventually.rejectedWith(
       AssertionError,
-      'Expected "One" event to have 4 argument(s), but has 3'
+      'Expected "One" event to have 4 argument(s), but it has 3'
     );
   });
 
@@ -134,7 +134,7 @@ describe('INTEGRATION: Events', () => {
         )
     ).to.be.eventually.rejectedWith(
       AssertionError,
-      'Expected "2" to be equal 1'
+      'Expected "1" to be equal 2'
     );
   });
 
@@ -149,7 +149,7 @@ describe('INTEGRATION: Events', () => {
         )
     ).to.be.eventually.rejectedWith(
       AssertionError,
-      'expected \'Two\' to equal \'One\''
+      'expected \'One\' to equal \'Two\''
     );
   });
 
@@ -164,8 +164,8 @@ describe('INTEGRATION: Events', () => {
         )
     ).to.be.eventually.rejectedWith(
       AssertionError,
-      'expected \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162124\' ' +
-        'to equal \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162123\''
+      'expected \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162123\' ' +
+        'to equal \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162124\''
     );
   });
 
@@ -206,8 +206,8 @@ describe('INTEGRATION: Events', () => {
         )
     ).to.be.eventually.rejectedWith(
       AssertionError,
-      'expected \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162121\' ' +
-        'to equal \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162123\''
+      'expected \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162123\' ' +
+        'to equal \'0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162121\''
     );
   });
 
@@ -225,7 +225,7 @@ describe('INTEGRATION: Events', () => {
     ).to.be.eventually.rejectedWith(
       AssertionError,
       // eslint-disable-next-line no-useless-escape
-      'Expected "0" to be equal 1'
+      'Expected "1" to be equal 0'
     );
   });
 

--- a/waffle-chai/test/matchers/events.test.ts
+++ b/waffle-chai/test/matchers/events.test.ts
@@ -52,7 +52,7 @@ describe('INTEGRATION: Events', () => {
     await expect(events.emitTwo()).to.not.emit(events, 'One');
   });
 
-  it('Emit unexistent event: fail', async () => {
+  it('Emit nonexistent event: fail', async () => {
     await expect(
       expect(events.emitOne()).to.emit(events, 'Three')
     ).to.be.eventually.rejectedWith(
@@ -62,7 +62,7 @@ describe('INTEGRATION: Events', () => {
     );
   });
 
-  it('Negate emit unexistent event: fail', async () => {
+  it('Negate emit nonexistent event: fail', async () => {
     await expect(
       expect(events.emitOne()).not.to.emit(events, 'Three')
     ).to.be.eventually.rejectedWith(
@@ -84,7 +84,7 @@ describe('INTEGRATION: Events', () => {
     await expect(events.emitBoth()).to.emit(events, 'Two');
   });
 
-  it('Emit both: success (one expect with two to)', async () => {
+  it('Emit both: success (one expect with two "to" prepositions)', async () => {
     await expect(events.emitBoth())
       .to.emit(events, 'One')
       .withArgs(
@@ -153,7 +153,7 @@ describe('INTEGRATION: Events', () => {
     );
   });
 
-  it('Event with one different arg (string)', async () => {
+  it('Event with one different arg (string) #2', async () => {
     await expect(
       expect(events.emitOne())
         .to.emit(events, 'One')


### PR DESCRIPTION
Context:
```solidity
function emitOne() public {
    emit One(1, "One", 0x00cFBbaF7DDB3a1476767101c12a0162e241fbAD2a0162e2410cFBbaF7162123);
}
```

Currently the following test:
```js
await expect(events.emitOne())
  .to.emit(events, 'One')
  .withArgs(1, 'Two', '0x00cfbbaf7ddb3a1476767101c12a0162e241fbad2a0162e2410cfbbaf7162123');
```

returns the following error message:
```
AssertionError: expected 'Two' to equal 'One'
Expected :One
Actual   :Two
```
which is clearly wrong because `Two` is not the actual value.


This PR fixes the error messages so in the above case it looks like this:
```
AssertionError: expected 'One' to equal 'Two'
Expected :Two
Actual   :One
```
