### PR TITLE
Mocks can now call and staticcall through to contracts

### DIFF
--- a/waffle-mock-contract/README.md
+++ b/waffle-mock-contract/README.md
@@ -70,6 +70,30 @@ await mockContract.mock['burn(uint256)'].returns(true)
 await mockContract.mock['burn(address,uint256)'].withArgs('0x1234...', 1000).reverts()
 ```
 
+You may wish to execute another contract through a mock.  Given the "AmIRichAlready" code below, you could call constant functions using `staticcall`:
+
+```js
+const contractFactory = new ContractFactory(AmIRichAlready.abi, AmIRichAlready.bytecode, sender);
+const amIRich = await contractFactory.deploy()
+const mockERC20 = await deployMockContract(sender, IERC20.abi);
+
+let result = await mockERC20.staticcall(amIRich, 'check()')
+
+expect(result).to.equal(true) // result will be true if you have enough tokens
+```
+
+You may also execute transactions through the mock, using `call`:
+
+```js
+const contractFactory = new ContractFactory(AmIRichAlready.abi, AmIRichAlready.bytecode, sender);
+const amIRich = await contractFactory.deploy()
+const mockERC20 = await deployMockContract(sender, IERC20.abi);
+
+let result = await mockERC20.call(amIRich, 'setRichness(uint256)', 1000)
+
+expect(await amIRich.richness()).to.equal('1000') // richness was updated
+```
+
 ## Example
 
 The example below illustrates how `mock-contract` can be used to test the very simple `AmIRichAlready` contract.
@@ -83,7 +107,7 @@ interface IERC20 {
 
 contract AmIRichAlready {
     IERC20 private tokenContract;
-    uint private constant RICHNESS = 1000000 * 10 ** 18;
+    uint public richness = 1000000 * 10 ** 18;
 
     constructor (IERC20 _tokenContract) public {
         tokenContract = _tokenContract;
@@ -91,7 +115,11 @@ contract AmIRichAlready {
 
     function check() public view returns (bool) {
         uint balance = tokenContract.balanceOf(msg.sender);
-        return balance > RICHNESS;
+        return balance > richness;
+    }
+
+    function setRichness(uint256 _richness) {
+      richness = _richness;
     }
 }
 ```

--- a/waffle-mock-contract/README.md
+++ b/waffle-mock-contract/README.md
@@ -78,7 +78,8 @@ const amIRich = await contractFactory.deploy()
 const mockERC20 = await deployMockContract(sender, IERC20.abi);
 
 let result = await mockERC20.staticcall(amIRich, 'check()')
-
+// you may also just use the function name
+result = await mockERC20.staticcall(amIRich, 'check')
 expect(result).to.equal(true) // result will be true if you have enough tokens
 ```
 
@@ -90,7 +91,8 @@ const amIRich = await contractFactory.deploy()
 const mockERC20 = await deployMockContract(sender, IERC20.abi);
 
 let result = await mockERC20.call(amIRich, 'setRichness(uint256)', 1000)
-
+// you may also just use the function name
+result = await mockERC20.call(amIRich, 'setRichness', 1000)
 expect(await amIRich.richness()).to.equal('1000') // richness was updated
 ```
 

--- a/waffle-mock-contract/src/Doppelganger.sol
+++ b/waffle-mock-contract/src/Doppelganger.sol
@@ -37,13 +37,13 @@ contract Doppelganger {
 
     function __waffle__call(address target, bytes calldata data) external returns (bytes memory) {
       (bool succeeded, bytes memory returnValue) = target.call(data);
-      require(succeeded, "Mock call failed");
+      require(succeeded, string(returnValue));
       return returnValue;
     }
 
     function __waffle__staticcall(address target, bytes calldata data) external view returns (bytes memory) {
       (bool succeeded, bytes memory returnValue) = target.staticcall(data);
-      require(succeeded, "Mock staticcall failed");
+      require(succeeded, string(returnValue));
       return returnValue;
     }
 

--- a/waffle-mock-contract/src/Doppelganger.sol
+++ b/waffle-mock-contract/src/Doppelganger.sol
@@ -35,6 +35,18 @@ contract Doppelganger {
         });
     }
 
+    function __waffle__call(address target, bytes calldata data) external returns (bytes memory) {
+      (bool succeeded, bytes memory returnValue) = target.call(data);
+      require(succeeded, "Mock call failed");
+      return returnValue;
+    }
+
+    function __waffle__staticcall(address target, bytes calldata data) external view returns (bytes memory) {
+      (bool succeeded, bytes memory returnValue) = target.staticcall(data);
+      require(succeeded, "Mock staticcall failed");
+      return returnValue;
+    }
+
     function __internal__getMockCall() view private returns (MockCall storage mockCall) {
         mockCall = mockConfig[keccak256(msg.data)];
         if (mockCall.initialized == true) {

--- a/waffle-mock-contract/src/index.ts
+++ b/waffle-mock-contract/src/index.ts
@@ -64,10 +64,10 @@ export async function deployMockContract(signer: Signer, abi: ABI): Promise<Mock
   mockedContract.staticcall = async (contract: Contract, functionName: string, ...params: any[]) => {
     let func: utils.FunctionFragment = contract.interface.functions[functionName];
     if (!func) {
-      func = Object.values(contract.interface.functions).find(f => f.name === functionName) as FunctionFragment
+      func = Object.values(contract.interface.functions).find(f => f.name === functionName) as FunctionFragment;
     }
     if (!func) {
-      throw new Error(`Unknown function ${functionName}`)
+      throw new Error(`Unknown function ${functionName}`);
     }
     if (!func.outputs) {
       throw new Error('Cannot staticcall function with no outputs');

--- a/waffle-mock-contract/src/index.ts
+++ b/waffle-mock-contract/src/index.ts
@@ -48,8 +48,8 @@ export interface MockContract extends Contract {
   mock: {
     [key: string]: Stub;
   };
-  call: Function
-  staticcall: Function
+  call: Function;
+  staticcall: Function;
 }
 
 export async function deployMockContract(signer: Signer, abi: ABI): Promise<MockContract> {
@@ -62,26 +62,26 @@ export async function deployMockContract(signer: Signer, abi: ABI): Promise<Mock
   const encoder = new utils.AbiCoder();
 
   mockedContract.staticcall = async (contract: Contract, functionName: string, ...params: any) => {
-    let func: utils.FunctionFragment = contract.interface.functions[functionName]
+    const func: utils.FunctionFragment = contract.interface.functions[functionName];
     if (!func.outputs) {
-      throw new Error('Cannot staticcall function with no outputs')
+      throw new Error('Cannot staticcall function with no outputs');
     }
-    let tx = await contract.populateTransaction[functionName](params)
-    let data = tx.data
-    let result
-    let returnValue = await mockContractInstance.__waffle__staticcall(contract.address, data)
+    const tx = await contract.populateTransaction[functionName](params);
+    const data = tx.data;
+    let result;
+    const returnValue = await mockContractInstance.__waffle__staticcall(contract.address, data);
     result = encoder.decode(func.outputs, returnValue);
-    if (result.length == 1) {
-      result = result[0]
+    if (result.length === 1) {
+      result = result[0];
     }
-    return result
-  }
+    return result;
+  };
 
   mockedContract.call = async (contract: Contract, functionName: string, ...params: any) => {
-    let tx = await contract.populateTransaction[functionName](params)
-    let data = tx.data
-    return await mockContractInstance.__waffle__call(contract.address, data)
-  }
+    const tx = await contract.populateTransaction[functionName](params);
+    const data = tx.data;
+    return mockContractInstance.__waffle__call(contract.address, data);
+  };
 
   return mockedContract;
 }

--- a/waffle-mock-contract/test/contract.test.ts
+++ b/waffle-mock-contract/test/contract.test.ts
@@ -127,31 +127,32 @@ describe('Doppelganger - Contract', () => {
   });
 
   describe('call mechanisms', () => {
-    let doppelganger: Contract
-    let counter: Contract
+    let doppelganger: Contract;
+    let counter: Contract;
 
     beforeEach(async () => {
       const doppelgangerFactory = new ContractFactory(DoppelgangerContract.abi, DoppelgangerContract.bytecode, wallet);
       doppelganger = await doppelgangerFactory.deploy();
       const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
-      counter = await counterFactory.deploy()
-    })
+      counter = await counterFactory.deploy();
+    });
 
     describe('staticcall()', () => {
       it('should allow a user to call a contract through the mock', async () => {
-        let fn = counter.interface.functions['read()']
-        let data = counter.interface.getSighash(fn)
-        expect(await doppelganger.__waffle__staticcall(counter.address, data)).to.equal('0x0000000000000000000000000000000000000000000000000000000000000000')
-      })
-    })
+        const fn = counter.interface.functions['read()'];
+        const data = counter.interface.getSighash(fn);
+        expect(await doppelganger.__waffle__staticcall(counter.address, data))
+          .to.equal('0x0000000000000000000000000000000000000000000000000000000000000000');
+      });
+    });
 
     describe('call()', () => {
       it('should allow a user to execute a transaction through the mock', async () => {
-        let fn = counter.interface.functions['increment()']
-        let data = counter.interface.getSighash(fn)
-        await doppelganger.__waffle__call(counter.address, data)
-        expect(await counter.read()).to.equal('1')
-      })
-    })
-  })
+        const fn = counter.interface.functions['increment()'];
+        const data = counter.interface.getSighash(fn);
+        await doppelganger.__waffle__call(counter.address, data);
+        expect(await counter.read()).to.equal('1');
+      });
+    });
+  });
 });

--- a/waffle-mock-contract/test/contract.test.ts
+++ b/waffle-mock-contract/test/contract.test.ts
@@ -125,4 +125,33 @@ describe('Doppelganger - Contract', () => {
       expect(await pretender.add(4)).to.equal(returnedValue);
     });
   });
+
+  describe('call mechanisms', () => {
+    let doppelganger: Contract
+    let counter: Contract
+
+    beforeEach(async () => {
+      const doppelgangerFactory = new ContractFactory(DoppelgangerContract.abi, DoppelgangerContract.bytecode, wallet);
+      doppelganger = await doppelgangerFactory.deploy();
+      const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
+      counter = await counterFactory.deploy()
+    })
+
+    describe('staticcall()', () => {
+      it('should allow a user to call a contract through the mock', async () => {
+        let fn = counter.interface.functions['read()']
+        let data = counter.interface.getSighash(fn)
+        expect(await doppelganger.__waffle__staticcall(counter.address, data)).to.equal('0x0000000000000000000000000000000000000000000000000000000000000000')
+      })
+    })
+
+    describe('call()', () => {
+      it('should allow a user to execute a transaction through the mock', async () => {
+        let fn = counter.interface.functions['increment()']
+        let data = counter.interface.getSighash(fn)
+        await doppelganger.__waffle__call(counter.address, data)
+        expect(await counter.read()).to.equal('1')
+      })
+    })
+  })
 });

--- a/waffle-mock-contract/test/direct.test.ts
+++ b/waffle-mock-contract/test/direct.test.ts
@@ -2,6 +2,7 @@ import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {MockProvider} from '@ethereum-waffle/provider';
 import {waffleChai} from '@ethereum-waffle/chai';
+import {Contract, ContractFactory} from 'ethers';
 
 import {deployMockContract} from '../src';
 import Counter from './helpers/interfaces/Counter.json';
@@ -43,4 +44,21 @@ describe('Mock Contract - Integration (called directly)', () => {
     await expect(mockCounter.add(2)).to.be.revertedWith('Mock revert');
     expect(await mockCounter.add(3)).to.equal(1);
   });
+
+  it('should be able to call to another contract', async () => {
+    const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
+    const counter = await counterFactory.deploy()
+    const mockCounter = await deployMockContract(wallet, Counter.abi);
+
+    expect(await mockCounter.staticcall(counter, 'read()')).to.equal('0')
+  })
+
+  it('should be able to execute another contract', async () => {
+    const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
+    const counter = await counterFactory.deploy()
+    const mockCounter = await deployMockContract(wallet, Counter.abi);
+
+    await mockCounter.call(counter, 'increment()')
+    expect(await counter.read()).to.equal('1')
+  })
 });

--- a/waffle-mock-contract/test/direct.test.ts
+++ b/waffle-mock-contract/test/direct.test.ts
@@ -2,7 +2,7 @@ import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {MockProvider} from '@ethereum-waffle/provider';
 import {waffleChai} from '@ethereum-waffle/chai';
-import {Contract, ContractFactory} from 'ethers';
+import {ContractFactory} from 'ethers';
 
 import {deployMockContract} from '../src';
 import Counter from './helpers/interfaces/Counter.json';
@@ -47,18 +47,18 @@ describe('Mock Contract - Integration (called directly)', () => {
 
   it('should be able to call to another contract', async () => {
     const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
-    const counter = await counterFactory.deploy()
+    const counter = await counterFactory.deploy();
     const mockCounter = await deployMockContract(wallet, Counter.abi);
 
-    expect(await mockCounter.staticcall(counter, 'read()')).to.equal('0')
-  })
+    expect(await mockCounter.staticcall(counter, 'read()')).to.equal('0');
+  });
 
   it('should be able to execute another contract', async () => {
     const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
-    const counter = await counterFactory.deploy()
+    const counter = await counterFactory.deploy();
     const mockCounter = await deployMockContract(wallet, Counter.abi);
 
-    await mockCounter.call(counter, 'increment()')
-    expect(await counter.read()).to.equal('1')
-  })
+    await mockCounter.call(counter, 'increment()');
+    expect(await counter.read()).to.equal('1');
+  });
 });

--- a/waffle-mock-contract/test/direct.test.ts
+++ b/waffle-mock-contract/test/direct.test.ts
@@ -51,6 +51,7 @@ describe('Mock Contract - Integration (called directly)', () => {
     const mockCounter = await deployMockContract(wallet, Counter.abi);
 
     expect(await mockCounter.staticcall(counter, 'read()')).to.equal('0');
+    expect(await mockCounter.staticcall(counter, 'read')).to.equal('0');
   });
 
   it('should be able to execute another contract', async () => {
@@ -60,5 +61,8 @@ describe('Mock Contract - Integration (called directly)', () => {
 
     await mockCounter.call(counter, 'increment()');
     expect(await counter.read()).to.equal('1');
+
+    await mockCounter.call(counter, 'increment');
+    expect(await counter.read()).to.equal('2');
   });
 });


### PR DESCRIPTION
- call will execute a tx on behalf of a mock
- staticcall will call a constant fxn on behalf of a mock