### PR TITLE
Replace uses of Wallet with Signer

### DIFF
--- a/waffle-chai/src/matchers/changeBalance.ts
+++ b/waffle-chai/src/matchers/changeBalance.ts
@@ -1,9 +1,9 @@
-import {Wallet, BigNumber} from 'ethers';
+import {BigNumber, Signer} from 'ethers';
 
 export function supportChangeBalance(Assertion: Chai.AssertionStatic) {
   Assertion.addMethod('changeBalance', function (
     this: any,
-    wallet: Wallet,
+    signer: Signer,
     balanceChange: any
   ) {
     const subject = this._obj;
@@ -11,13 +11,16 @@ export function supportChangeBalance(Assertion: Chai.AssertionStatic) {
       throw new Error(`Expect subject should be a callback returning the Promise
         e.g.: await expect(() => wallet.send({to: '0xb', value: 200})).to.changeBalance('0xa', -200)`);
     }
-    const derivedPromise = getBalanceChange(subject, wallet).then(
-      (actualChange) => {
+    const derivedPromise = Promise.all([
+      getBalanceChange(subject, signer),
+      signer.getAddress()
+    ]).then(
+      ([actualChange, address]) => {
         this.assert(
           actualChange.eq(BigNumber.from(balanceChange)),
-          `Expected "${wallet.address}" to change balance by ${balanceChange} wei, ` +
+          `Expected "${address}" to change balance by ${balanceChange} wei, ` +
             `but it has changed by ${actualChange} wei`,
-          `Expected "${wallet.address}" to not change balance by ${balanceChange} wei,`,
+          `Expected "${address}" to not change balance by ${balanceChange} wei,`,
           balanceChange,
           actualChange
         );
@@ -32,10 +35,10 @@ export function supportChangeBalance(Assertion: Chai.AssertionStatic) {
 
 export async function getBalanceChange(
   transactionCallback: () => any,
-  wallet: Wallet
+  signer: Signer
 ) {
-  const balanceBefore = await wallet.getBalance();
+  const balanceBefore = await signer.getBalance();
   await transactionCallback();
-  const balanceAfter = await wallet.getBalance();
+  const balanceAfter = await signer.getBalance();
   return balanceAfter.sub(balanceBefore);
 }

--- a/waffle-provider/src/fixtures.ts
+++ b/waffle-provider/src/fixtures.ts
@@ -1,18 +1,18 @@
-import {providers, Wallet} from 'ethers';
+import {providers, Signer} from 'ethers';
 import {MockProvider} from './MockProvider';
 
-type Fixture<T> = (wallets: Wallet[], provider: MockProvider) => Promise<T>;
+type Fixture<T> = (signers: Signer[], provider: MockProvider) => Promise<T>;
 interface Snapshot<T> {
   fixture: Fixture<T>;
   data: T;
   id: string;
   provider: providers.Web3Provider;
-  wallets: Wallet[];
+  signers: Signer[];
 }
 
 export const loadFixture = createFixtureLoader();
 
-export function createFixtureLoader(overrideWallets?: Wallet[], overrideProvider?: MockProvider) {
+export function createFixtureLoader(overrideSigners?: Signer[], overrideProvider?: MockProvider) {
   const snapshots: Snapshot<any>[] = [];
 
   return async function load<T>(fixture: Fixture<T>): Promise<T> {
@@ -23,12 +23,12 @@ export function createFixtureLoader(overrideWallets?: Wallet[], overrideProvider
       return snapshot.data;
     } else {
       const provider = overrideProvider ?? new MockProvider();
-      const wallets = overrideWallets ?? provider.getWallets();
+      const signers = overrideSigners ?? provider.getWallets();
 
-      const data = await fixture(wallets, provider);
+      const data = await fixture(signers, provider);
       const id = await provider.send('evm_snapshot', []);
 
-      snapshots.push({fixture, data, id, provider, wallets});
+      snapshots.push({fixture, data, id, provider, signers});
       return data;
     }
   };


### PR DESCRIPTION
Hey @marekkirejczyk @sz-piotr,

I found some issues when using Waffle with Buidler, so I made this PR to fix them.

Some of Waffle's APIs use `Wallet` to type their parameters, but `Signer` could be used instead. This is a problem with Buidler because it sometimes connects to remote networks, and you can't have `Wallet`s in that case.

I changed the fixtures API, and in two chai matches, so that now they receive `Signer`. Luckily this is a backward-compatible change.

Now, the only uses of `Wallet` are left in the `MockProvider`, which I think makes sense.

Do you think we can get this into Waffle `3.0.2`?