### PR TITLE
adding extra BigNumber matchers to the docs

### DIFF
--- a/docs/source/matchers.rst
+++ b/docs/source/matchers.rst
@@ -20,7 +20,7 @@ Testing equality of big numbers:
 
   expect(await token.balanceOf(wallet.address)).to.equal(993);
 
-Available matchers for BigNumbers are: `equal`, `eq`, `above`, `below`, `least`, `most`.
+Available matchers for BigNumbers are: `equal`, `eq`, `above`, `gt`, `gte`, `below`, `lt`, `lte`, `least`, `most`.
 
 Emitting events
 ---------------


### PR DESCRIPTION
Was looking for this matches at the documentation and they were not there.
Then I saw that these matchers were added in the release (2.4.1 )[#214]
