### PR TITLE
docs: mention "revertsWithReason"

### DIFF
--- a/docs/source/mock-contract.rst
+++ b/docs/source/mock-contract.rst
@@ -29,7 +29,9 @@ Methods can also be set up to be reverted using:
 .. code-block:: ts
 
   await mockContract.mock.<nameOfMethod>.reverts()
+  await mockContract.mock.<nameOfMethod>.revertsWithReason(<reason>)
   await mockContract.mock.<nameOfMethod>.withArgs(<arguments>).reverts()
+  await mockContract.mock.<nameOfMethod>.withArgs(<arguments>).revertsWithReason(<reason>)
 
 Example
 -------


### PR DESCRIPTION
As per #349, Waffle can now support arbitrary revert reasons when mocking a contract.

This PR documents the newly added behaviour.