### PR TITLE
Add missing spread operator

### DIFF
--- a/waffle-mock-contract/src/index.ts
+++ b/waffle-mock-contract/src/index.ts
@@ -85,7 +85,7 @@ export async function deployMockContract(signer: Signer, abi: ABI): Promise<Mock
   };
 
   mockedContract.call = async (contract: Contract, functionName: string, ...params: any[]) => {
-    const tx = await contract.populateTransaction[functionName](params);
+    const tx = await contract.populateTransaction[functionName](...params);
     const data = tx.data;
     return mockContractInstance.__waffle__call(contract.address, data);
   };

--- a/waffle-mock-contract/src/index.ts
+++ b/waffle-mock-contract/src/index.ts
@@ -73,7 +73,7 @@ export async function deployMockContract(signer: Signer, abi: ABI): Promise<Mock
     if (!func.outputs) {
       throw new Error('Cannot staticcall function with no outputs');
     }
-    const tx = await contract.populateTransaction[functionName](params);
+    const tx = await contract.populateTransaction[functionName](...params);
     const data = tx.data;
     let result;
     const returnValue = await mockContractInstance.__waffle__staticcall(contract.address, data);

--- a/waffle-mock-contract/test/direct.test.ts
+++ b/waffle-mock-contract/test/direct.test.ts
@@ -54,6 +54,22 @@ describe('Mock Contract - Integration (called directly)', () => {
     expect(await mockCounter.staticcall(counter, 'read')).to.equal('0');
   });
 
+  it('should be able to call another contract with a parameter', async () => {
+    const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
+    const counter = await counterFactory.deploy();
+    const mockCounter = await deployMockContract(wallet, Counter.abi);
+
+    expect(await mockCounter.staticcall(counter, 'add', 1)).to.equal('1');
+  });
+
+  it('should be able to call another contract with many parameters', async () => {
+    const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
+    const counter = await counterFactory.deploy();
+    const mockCounter = await deployMockContract(wallet, Counter.abi);
+
+    expect(await mockCounter.staticcall(counter, 'addThree', 1, 2, 3)).to.equal('6');
+  });
+
   it('should be able to execute another contract', async () => {
     const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
     const counter = await counterFactory.deploy();
@@ -64,5 +80,23 @@ describe('Mock Contract - Integration (called directly)', () => {
 
     await mockCounter.call(counter, 'increment');
     expect(await counter.read()).to.equal('2');
+  });
+
+  it('should be able to execute another contract with a parameter', async () => {
+    const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
+    const counter = await counterFactory.deploy();
+    const mockCounter = await deployMockContract(wallet, Counter.abi);
+
+    await mockCounter.call(counter, 'increaseBy', 2);
+    expect(await counter.read()).to.equal('2');
+  });
+
+  it('should be able to execute another contract with many parameters', async () => {
+    const counterFactory = new ContractFactory(Counter.abi, Counter.bytecode, wallet);
+    const counter = await counterFactory.deploy();
+    const mockCounter = await deployMockContract(wallet, Counter.abi);
+
+    await mockCounter.call(counter, 'increaseByThreeValues', 1, 2, 3);
+    expect(await counter.read()).to.equal('6');
   });
 });

--- a/waffle-mock-contract/test/helpers/contracts/Counter.sol
+++ b/waffle-mock-contract/test/helpers/contracts/Counter.sol
@@ -7,12 +7,36 @@ contract Counter {
         value += 1;
     }
 
+    function increaseBy(uint a) public {
+        require(a > 0, "A must be greater than 0");
+
+        value += a;
+    }
+
+    function increaseByThreeValues(uint a, uint b, uint c) public {
+        require(a > 0, "A must be greater than 0");
+        require(b > 0, "B must be greater than 0");
+        require(c > 0, "C must be greater than 0");
+
+        value += a;
+        value += b;
+        value += c;
+    }
+
     function read() public view returns (uint) {
         return value;
     }
 
     function add(uint a) public view returns (uint) {
         return value + a;
+    }
+
+    function addThree(uint a, uint b, uint c) public view returns (uint) {
+        require(a > 0, "A must be greater than 0");
+        require(b > 0, "B must be greater than 0");
+        require(c > 0, "C must be greater than 0");
+
+        return value + a + b + c;
     }
 
     function testArgumentTypes(uint a, bool b, string memory s, bytes memory bs) public pure returns (bytes memory ret) {


### PR DESCRIPTION
Adds missing spread syntax for the parameters for populateTransaction call as specified in [ethers v5 documentation](https://docs.ethers.io/v5/api/contract/contract/#contract-populateTransaction).

Closes #340 