### PR TITLE
Update deployContract.ts

### DIFF
--- a/waffle-cli/src/deployContract.ts
+++ b/waffle-cli/src/deployContract.ts
@@ -1,11 +1,6 @@
 import {providers, ContractFactory, Signer} from 'ethers';
 import {ContractJSON, isStandard, hasByteCode} from './ContractJSON';
 
-const defaultDeployOptions = {
-  gasLimit: 4000000,
-  gasPrice: 9000000000
-};
-
 export async function deployContract(
   signer: Signer,
   contractJSON: ContractJSON,
@@ -22,7 +17,6 @@ export async function deployContract(
     signer
   );
   const contract = await factory.deploy(...args, {
-    ...defaultDeployOptions,
     ...overrideOptions
   });
   await contract.deployed();


### PR DESCRIPTION
Remove default deployment `gasPrice` and `gasLimit`

As far as I can tell, there is no reason to have these set as the default. `ethers` will calculate and inject sane defaults already, based on the network's current gas usage, and the size of the contract.

By including these defaults, it requires that the user manually override when attempting to deploy to a network with gas prices higher than 9 Gwei (like mainnet), or if the contract itself is larger than 4,000,000 GAS (otherwise the transaction will fail). By not including these defaults, everything will "just work", and the user is still free to override at their convenience.

This change was a quick GitHub-editor-based update. I assume there are tests for me to update? Before I spend time on that, does the spirit of this PR make sense?

edit: I _did_ verify that the removal of this code actually does work as intended, in a local project which has a contract larger than 4,000,000 gas. The submitted transaction uses the current network's average gas price, and a gas limit equal to the size of the contract itself.