### PR TITLE
feat: bump deployContract gas limit to 6721975

### DIFF
--- a/waffle-cli/src/deployContract.ts
+++ b/waffle-cli/src/deployContract.ts
@@ -2,7 +2,7 @@ import {providers, ContractFactory, Signer} from 'ethers';
 import {ContractJSON, isStandard, hasByteCode} from './ContractJSON';
 
 const defaultDeployOptions = {
-  gasLimit: 4000000,
+  gasLimit: 6721975,
   gasPrice: 9000000000
 };
 


### PR DESCRIPTION
## Description

The [current][1] gas limit of 4,000,000 causes hard-to-debug errors for users:

```
Error: VM Exception while processing transaction: out of gas
at HttpProvider.send (node_modules/@nomiclabs/buidler/src/internal/core/providers/http.ts:36:34)
at /Users/paulrberg/Workspace/Mainframe/mainframe-lending-protocol/node_modules/@nomiclabs/buidler/src/internal/core/providers/gas-providers.ts:115:21
at Proxy.cloningSendWrapper (node_modules/@nomiclabs/buidler/src/internal/core/providers/wrapper.ts:9:12)
at /Users/paulrberg/Workspace/Mainframe/mainframe-lending-protocol/node_modules/@nomiclabs/buidler/src/internal/core/providers/accounts.ts:219:21
at Proxy.cloningSendWrapper (node_modules/@nomiclabs/buidler/src/internal/core/providers/wrapper.ts:9:12)
at /Users/paulrberg/Workspace/Mainframe/mainframe-lending-protocol/node_modules/@nomiclabs/buidler/src/internal/core/providers/gas-providers.ts:63:21
at Proxy.cloningSendWrapper (node_modules/@nomiclabs/buidler/src/internal/core/providers/wrapper.ts:9:12)
at /Users/paulrberg/Workspace/Mainframe/mainframe-lending-protocol/node_modules/@nomiclabs/buidler/src/internal/core/providers/gas-providers.ts:82:21
at Proxy.cloningSendWrapper (node_modules/@nomiclabs/buidler/src/internal/core/providers/wrapper.ts:9:12)
at EthersProviderWrapper.send (node_modules/@nomiclabs/buidler-ethers/src/ethers-provider-wrapper.ts:13:48)
at /Users/paulrberg/Workspace/Mainframe/mainframe-lending-protocol/node_modules/ethers/node_modules/@ethersproject/providers/src.ts/json-rpc-provider.ts:178:34
at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

It wasn't obvious that this was caused by Waffle's `deployContract` limit. After all, it's the local network provider that throws the "out of gas" error". After a few hours of debugging my Hardhat Network [configuration][2] config, ensuring that the "gas" and "blockGasLimit" fields have high enough values, I realised that the issue is caused by the `deployContract` hardcoded gas limit.

## Proposed Change

Change the limit from 4,000,000 to 6,721,975. The latter is used by [ganache-cli][3] too and it would give developers more leeway before running into "out of gas" errors.

[1]: https://github.com/EthWorks/Waffle/blob/e597b2bf3e568b9d624902ed12a97b8b20f99674/waffle-cli/src/deployContract.ts#L5
[2]: https://hardhat.org/config/#json-rpc-based-networks
[3]: https://github.com/trufflesuite/ganache-cli