### PR TITLE
Docs: replace "proper secret" with "proper private key"

### DIFF
--- a/docs/source/matchers.rst
+++ b/docs/source/matchers.rst
@@ -153,7 +153,7 @@ Testing if a string is a proper address:
 
 Proper private key
 ------------------
-Testing if a string is a proper secret:
+Testing if a string is a proper private key:
 
 .. code-block:: ts
 


### PR DESCRIPTION
Little wording change; the previous sentence seemed unfinished.