### PR TITLE
Make solcjs compilation work with versions >=0.7.2

### DIFF
--- a/waffle-compiler/src/compileSolcjs.ts
+++ b/waffle-compiler/src/compileSolcjs.ts
@@ -50,7 +50,7 @@ async function resolveSemverVersion(version: string) {
   return item.substring('soljson-'.length, item.length - '.js'.length);
 }
 
-const VERSION_LIST_URL = 'https://ethereum.github.io/solc-bin/bin/list.json';
+const VERSION_LIST_URL = 'https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/list.json';
 let cache: any = undefined;
 
 async function fetchReleases() {


### PR DESCRIPTION
For calculating solcjs binaries download paths we use a list of compiler versions fetched from [this github page](https://ethereum.github.io/solc-bin/bin/list.json). It seems the repository that publishes it [run out of disc space](https://github.com/ethereum/solc-bin/runs/1179669192) and the list has not been updated since September 26.

I changed the list url to point to the current version of the file taken directly from github repository.