### PR TITLE
Correct version list url

### DIFF
--- a/waffle-compiler/src/compileSolcjs.ts
+++ b/waffle-compiler/src/compileSolcjs.ts
@@ -50,7 +50,7 @@ async function resolveSemverVersion(version: string) {
   return item.substring('soljson-'.length, item.length - '.js'.length);
 }
 
-const VERSION_LIST_URL = 'https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/list.json';
+const VERSION_LIST_URL = 'https://solc-bin.ethereum.org/bin/list.json';
 let cache: any = undefined;
 
 async function fetchReleases() {
@@ -78,7 +78,7 @@ async function cacheRemoteVersion(version: string, cacheDirectory: string) {
 
   const filePath = path.join(solcCacheDirectory, `${version}.js`);
   const file = fs.createWriteStream(filePath);
-  const url = `https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/soljson-${version}.js`;
+  const url = `https://solc-bin.ethereum.org/bin/soljson-${version}.js`;
 
   await new Promise((resolve, reject) => {
     https.get(url, (response) => {

--- a/waffle-compiler/test/mocha.opts
+++ b/waffle-compiler/test/mocha.opts
@@ -1,4 +1,4 @@
 -r ts-node/register/transpile-only
 --timeout 50000
 --no-warnings
-test/**/*.{js,ts}
+test/**/*.ts


### PR DESCRIPTION
Changes the version list url to `https://solc-bin.ethereum.org/bin/list.json`.
The change in mocha.opts is to prevent mocha from loading the cached versions of solc saved as js files.

@cameel I wanted to use the emscripten-wasm32 builds, but found that for some reason they aren't faster and using them made the tests timeout. I don't have more time to investigate the issue so we are sticking with `bin` for now.

Edit: the issue seems to only be related to node 10 #396. I suspect we will merge this PR and add support for wasm at a later date
