### PR TITLE
Rough fix proposal as foundation for discussion

### DIFF
--- a/waffle-provider/src/fixtures.ts
+++ b/waffle-provider/src/fixtures.ts
@@ -22,6 +22,7 @@ export function createFixtureLoader(overrideWallets?: Wallet[], overrideProvider
       await snapshot.provider.send('evm_revert', [snapshot.id]);
 
       // revert provider internal state (NOTE!!! This is fragile)
+      // see: https://github.com/ethers-io/ethers.js/issues/1383 in order to replace with a better solution
       snapshot.provider._maxInternalBlockNumber = 0;
 
       snapshot.id = await snapshot.provider.send('evm_snapshot', []);

--- a/waffle-provider/src/fixtures.ts
+++ b/waffle-provider/src/fixtures.ts
@@ -18,7 +18,12 @@ export function createFixtureLoader(overrideWallets?: Wallet[], overrideProvider
   return async function load<T>(fixture: Fixture<T>): Promise<T> {
     const snapshot = snapshots.find((snapshot) => snapshot.fixture === fixture);
     if (snapshot) {
+      // revert blockchain state
       await snapshot.provider.send('evm_revert', [snapshot.id]);
+
+      // revert provider internal state (NOTE!!! This is fragile)
+      snapshot.provider._maxInternalBlockNumber = 0;
+
       snapshot.id = await snapshot.provider.send('evm_snapshot', []);
       return snapshot.data;
     } else {


### PR DESCRIPTION
As I wrote:
// revert provider internal state (NOTE!!! This is fragile)
snapshot.provider._maxInternalBlockNumber = 0;

I believe that's not an option from the good quality standpoint.

I also see that the base provider resets its internal cache/state on network
changes. But do you know if/how I can use it straightforward in the mock provider? Even if yes, doesn't it contradict the fundamental design of Waffle (to have fixtures reset quickly and have good perf.; if such networks resets slow even in mocked env, so the perf deteriorates right)?