### PR TITLE
Lazy load ganache-core to avoid laoding `source-map-support` too early

### DIFF
--- a/waffle-provider/src/MockProvider.ts
+++ b/waffle-provider/src/MockProvider.ts
@@ -1,7 +1,7 @@
 import {providers, Wallet} from 'ethers';
 import {CallHistory, RecordedCall} from './CallHistory';
 import {defaultAccounts} from './defaultAccounts';
-import Ganache from 'ganache-core';
+import type Ganache from 'ganache-core';
 import {deployENS, ENS} from '@ethereum-waffle/ens';
 
 export {RecordedCall};
@@ -15,7 +15,7 @@ export class MockProvider extends providers.Web3Provider {
   private _ens?: ENS;
 
   constructor(private options?: MockProviderOptions) {
-    super(Ganache.provider({accounts: defaultAccounts, ...options?.ganacheOptions}) as any);
+    super(require("ganache").provider({accounts: defaultAccounts, ...options?.ganacheOptions}) as any);
     this._callHistory = new CallHistory();
     this._callHistory.record(this);
   }


### PR DESCRIPTION
This fixes: https://github.com/EthWorks/Waffle/issues/281 (again)

I consider it being a tmp fix, real fix is:
1. Avoid requiring `source-map-support` by `ganache-core`
2. Improve `source-map-support` to detect double register - this might be harder as it doesn't seem to be maintained anymore. 

I am gonna follow up on both of these and see what can I do. 