### PR TITLE
Lazy load ganache-core to avoid laoding `source-map-support` too early

### DIFF
--- a/waffle-provider/src/MockProvider.ts
+++ b/waffle-provider/src/MockProvider.ts
@@ -1,7 +1,7 @@
 import {providers, Wallet} from 'ethers';
 import {CallHistory, RecordedCall} from './CallHistory';
 import {defaultAccounts} from './defaultAccounts';
-import Ganache from 'ganache-core';
+import type Ganache from 'ganache-core';
 import {deployENS, ENS} from '@ethereum-waffle/ens';
 
 export {RecordedCall};
@@ -15,7 +15,7 @@ export class MockProvider extends providers.Web3Provider {
   private _ens?: ENS;
 
   constructor(private options?: MockProviderOptions) {
-    super(Ganache.provider({accounts: defaultAccounts, ...options?.ganacheOptions}) as any);
+    super(require("ganache-core").provider({accounts: defaultAccounts, ...options?.ganacheOptions}) as any);
     this._callHistory = new CallHistory();
     this._callHistory.record(this);
   }


### PR DESCRIPTION
This fixes: https://github.com/EthWorks/Waffle/issues/281 (again)

EDIT:
After more investigation I realized that this is a bug only if a hardhat user imports anything from `waffle` rather than `waffle` provided in HRE. I feel like merging could improve life for some people but it boils down to a mistake on user's side.