### PR TITLE
chore: use trimmed down ganache-core

### DIFF
--- a/.changeset/selfish-shoes-tease.md
+++ b/.changeset/selfish-shoes-tease.md
@@ -1,0 +1,6 @@
+---
+"@ethereum-waffle/ens": patch
+"@ethereum-waffle/provider": patch
+---
+
+Updates ganache-core to 2.13.2 to take advantage of the [recent removal](https://github.com/trufflesuite/ganache-core/commit/a74efcec6b868e5778609dd95d26e5cd1f32e43a#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) of a few bundled dependencies, making waffle a lighter dependency itself

--- a/waffle-ens/package.json
+++ b/waffle-ens/package.json
@@ -44,6 +44,6 @@
     "ethers": "^5.0.1"
   },
   "devDependencies": {
-    "ganache-core": "^2.10.2"
+    "ganache-core": "^2.13.2"
   }
 }

--- a/waffle-provider/package.json
+++ b/waffle-provider/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@ethereum-waffle/ens": "^3.2.2",
     "ethers": "^5.0.1",
-    "ganache-core": "^2.10.2",
+    "ganache-core": "^2.13.2",
     "patch-package": "^6.2.2",
     "postinstall-postinstall": "^2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4910,7 +4910,7 @@ functional-red-black-tree@^1.0.1, functional-red-black-tree@~1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-ganache-core@^2.10.2:
+ganache-core@^2.13.2:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.13.2.tgz#27e6fc5417c10e6e76e2e646671869d7665814a3"
   integrity sha512-tIF5cR+ANQz0+3pHWxHjIwHqFXcVo0Mb+kcsNhglNFALcYo49aQpnS9dqHartqPfMFjiHh/qFoD3mYK0d/qGgw==


### PR DESCRIPTION
Ganache-core recently trimmed down a lot of its dependencies. It'd be nice if we moved to that version, to make the package smaller: https://github.com/trufflesuite/ganache-core/commit/a74efcec6b868e5778609dd95d26e5cd1f32e43a#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519.

The `examples/` also need to be updated but I was not sure which version tag to assign.