### PR TITLE
Add `equals` override for BigNumber

### DIFF
--- a/waffle-chai/src/matchers/bigNumber.ts
+++ b/waffle-chai/src/matchers/bigNumber.ts
@@ -4,6 +4,7 @@ export function supportBigNumber(
   Assertion: Chai.AssertionStatic,
   utils: Chai.ChaiUtils
 ) {
+  Assertion.overwriteMethod('equals', override('eq', 'equal', utils));
   Assertion.overwriteMethod('equal', override('eq', 'equal', utils));
   Assertion.overwriteMethod('eq', override('eq', 'equal', utils));
 


### PR DESCRIPTION
Chai has 3 ways to reference the `equal` assertion: `equal`, `eq`, and `equals` (ref https://github.com/chaijs/chai/blob/main/lib/chai/core/assertions.js#L1049-L1051). This adds the `equals` assertion to the overrides for BigNumbers