### PR TITLE
fix: bump node-fetch version

### DIFF
--- a/waffle-compiler/package.json
+++ b/waffle-compiler/package.json
@@ -45,7 +45,7 @@
     "@types/node-fetch": "^2.5.5",
     "ethers": "^5.0.1",
     "mkdirp": "^0.5.1",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "solc": "^0.6.3",
     "ts-generator": "^0.1.1",
     "typechain": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7269,7 +7269,7 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
-node-fetch@^2.6.0:
+node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
`node-fetch@2.6.0` has a security advisory out. Although the advisory isn't relevant to waffle, it *does* result in the following dependabot alert:

<img width="844" alt="Screen Shot 2021-04-07 at 7 34 11 PM" src="https://user-images.githubusercontent.com/14298799/113959729-3c941580-97d8-11eb-9f5d-5b6ebc663ce9.png">

the perfectionist in me would like for this alert to go away.

fixes #431 