### PR TITLE
Fix typechain related docs and configs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -299,7 +299,7 @@ typechain
 ^^^^^^^^^
 
 Waffle supports `typechain <https://github.com/ethereum-ts/TypeChain>`__ artifacts generation.
-To enable typed artifacts generation you should set :code:`typechainEnable` property to :code:`true`.
+To enable typed artifacts generation you should set :code:`typechainEnabled` property to :code:`true`.
 You are also able to define target folder for your artifacts by defining :code:`typechainOutputDir` property, which is set to :code:`./types` by default.
 Property :code:`typechainOutputDir` is a path relative to :ref:`outputDirectory`.
 
@@ -308,7 +308,7 @@ Example:
 .. code-block:: json
 
   {
-    "typechainEnable": true,
+    "typechainEnabled": true,
     "typechainOutputDir": "typechain"
   }
 

--- a/examples/typechain/waffle.json
+++ b/examples/typechain/waffle.json
@@ -3,8 +3,6 @@
   "compilerVersion": "0.6.2",
   "sourceDirectory": "./src",
   "outputDirectory": "./build",
-  "typechain": {
-    "enabled": true,
-    "outputDir": "../typechain"
-  }
+  "typechainEnabled": true,
+  "typechainOutputDir": "../typechain"
 }

--- a/waffle-cli/README.md
+++ b/waffle-cli/README.md
@@ -180,9 +180,7 @@ Example configuration file looks like this (all fields optional):
 To enable generation of [typechain](https://github.com/ethereum-ts/TypeChain) artifacts:
 ```json
 {
-  "typechain": {
-    "enable": true
-  }
+  "typechainEnabled": true
 }
 ```
 


### PR DESCRIPTION
Some typechain related docs and configs were not correct (out-of-sync, typos etc.)
Now it's fixed.